### PR TITLE
fix(catalog): restore soft-deleted flow instead of crashing on re-install

### DIFF
--- a/packages/shared/src/database/repositories/workflow-repository.ts
+++ b/packages/shared/src/database/repositories/workflow-repository.ts
@@ -262,6 +262,27 @@ export class WorkflowRepository {
   }
 
   /**
+   * Resolve a slug to a workflow ID INCLUDING soft-deleted rows.
+   *
+   * A soft-deleted row still occupies the (userId, slug) uniqueness slot — the unique index
+   * `workflow_user_slug_idx` does not exclude deleted rows — so a plain INSERT of the same
+   * (userId, slug) collides with "slug already exists". The catalog loader uses this to find such a
+   * row and restore + update it instead of inserting. Normal lookups must use `resolveSlug`, which
+   * ignores deleted flows.
+   */
+  async resolveSlugIncludingDeleted(slug: string, userId: string): Promise<string | null> {
+    const normalizedSlug = normalizeSlug(slug);
+
+    const [row] = await this.db
+      .select({ id: workflow.id })
+      .from(workflow)
+      .where(and(eq(workflow.slug, normalizedSlug), eq(workflow.userId, userId)))
+      .limit(1);
+
+    return row?.id ?? null;
+  }
+
+  /**
    * Resolve a slug to workflow ID, allowing public access
    * @param slug - Workflow slug
    * @param ownerUserId - Owner user ID (not current user)

--- a/packages/shared/src/services/workflow-catalog-loader.ts
+++ b/packages/shared/src/services/workflow-catalog-loader.ts
@@ -55,6 +55,10 @@ export interface CatalogLoadResult {
 /** Minimal repository surface the loader needs (satisfied by WorkflowRepository). */
 export interface CatalogWorkflowRepo {
   resolveSlug(slug: string, ownerUserId: string): Promise<string | null>;
+  /** Resolve including soft-deleted rows — they still occupy the (owner, slug) uniqueness slot. */
+  resolveSlugIncludingDeleted(slug: string, ownerUserId: string): Promise<string | null>;
+  /** Un-delete a soft-deleted flow so the install can update it instead of colliding on INSERT. */
+  restore(workflowId: string, ownerUserId: string): Promise<boolean>;
   get(
     workflowId: string,
     userId: string,
@@ -116,11 +120,27 @@ export async function installCatalogEntry(
     return "invalid-version";
   }
 
-  const existingWorkflowId = await workflowRepo.resolveSlug(slug, owner);
-  const workflowExists = !!existingWorkflowId;
+  let existingWorkflowId = await workflowRepo.resolveSlug(slug, owner);
+  let workflowExists = !!existingWorkflowId;
 
+  // A soft-deleted row still occupies the (owner, slug) uniqueness slot, so a plain INSERT would
+  // collide ("slug already exists for this user") — resolveSlug hides it, but slugExists and the
+  // unique index do not. Restore it and take the update path: catalog install is idempotent and a
+  // bundled flow is meant to exist on the target. The subsequent save() update un-deletes and
+  // overwrites it (version-gated below).
+  if (!workflowExists) {
+    const softDeletedId = await workflowRepo.resolveSlugIncludingDeleted(slug, owner);
+    if (softDeletedId) {
+      await workflowRepo.restore(softDeletedId, owner);
+      existingWorkflowId = softDeletedId;
+      workflowExists = true;
+      log(`  ♻️  ${owner}/${slug} (restored soft-deleted flow)`);
+    }
+  }
+
+  // Invariant past this point: workflowExists ⟺ existingWorkflowId !== null (set together above).
   if (workflowExists && !force) {
-    const existing = await workflowRepo.get(existingWorkflowId, owner);
+    const existing = await workflowRepo.get(existingWorkflowId!, owner);
     const serverVersion = existing?.metadata?.version;
 
     if (localVersion && serverVersion && isValidSemver(serverVersion)) {
@@ -148,7 +168,7 @@ export async function installCatalogEntry(
   if (!workflowExists) {
     delete graphForSave.id;
   } else {
-    graphForSave.id = existingWorkflowId;
+    graphForSave.id = existingWorkflowId!;
   }
 
   await mutationService.save({

--- a/tests/integration/workflow-catalog-loader.test.ts
+++ b/tests/integration/workflow-catalog-loader.test.ts
@@ -199,6 +199,43 @@ describe("Workflow Catalog Loader Integration", () => {
     expect(await deps.workflowRepo.resolveSlug(slug, OWNER_B)).toBe(idB);
   });
 
+  test("restores and updates a soft-deleted flow instead of failing with a slug collision", async () => {
+    const slug = `loader-softdeleted-${Date.now()}`;
+
+    // Install, then soft-delete it — simulating a prod row that was previously soft-deleted while
+    // its (owner, slug) slot stays occupied by the unique index.
+    await installCatalogEntries([entry(OWNER_A, slug, "1.0.0")], deps);
+    const id = await deps.workflowRepo.resolveSlug(slug, OWNER_A);
+    expect(id).toBeTruthy();
+    await deps.workflowRepo.softDelete(id!, OWNER_A);
+    expect(await deps.workflowRepo.resolveSlug(slug, OWNER_A)).toBeNull(); // hidden, but slot taken
+
+    // Re-installing the bundled flow must NOT throw "slug already exists" — it restores + updates.
+    const result = await installCatalogEntries([entry(OWNER_A, slug, "1.1.0")], deps);
+    expect(result.updated).toBe(1);
+    expect(result.installed).toBe(0);
+
+    // Same row is active again (same id), with the newer version.
+    const restoredId = await deps.workflowRepo.resolveSlug(slug, OWNER_A);
+    expect(restoredId).toBe(id);
+    const stored = await deps.workflowRepo.get(restoredId!, OWNER_A);
+    expect(stored?.metadata?.version).toBe("1.1.0");
+  });
+
+  test("restores a soft-deleted flow even when the bundled version is unchanged", async () => {
+    const slug = `loader-softdeleted-same-${Date.now()}`;
+
+    await installCatalogEntries([entry(OWNER_A, slug, "1.0.0")], deps);
+    const id = await deps.workflowRepo.resolveSlug(slug, OWNER_A);
+    await deps.workflowRepo.softDelete(id!, OWNER_A);
+    expect(await deps.workflowRepo.resolveSlug(slug, OWNER_A)).toBeNull();
+
+    // Same version + same content → no INSERT collision, and the flow is brought back to active.
+    const result = await installCatalogEntries([entry(OWNER_A, slug, "1.0.0")], deps);
+    expect(result.installed).toBe(0);
+    expect(await deps.workflowRepo.resolveSlug(slug, OWNER_A)).toBe(id);
+  });
+
   describe("multi-directory catalog → install (Step 2 end-to-end)", () => {
     const ORIGINAL_ENV = { ...process.env };
 


### PR DESCRIPTION
## Problem

The workflow catalog loader (run by `init-database` on every deploy) crashed with:

```
Migration failed: Error: Slug 'software-development-flow-lite' already exists for this user
```

whenever a bundled flow's `(owner, slug)` matched a **soft-deleted** row on the target DB.

### Root cause

`resolveSlug()` excludes soft-deleted rows (returns `null`), so the loader took the **INSERT** path. But `slugExists()` and the unique index `workflow_user_slug_idx` **do not** exclude deleted rows — a soft-deleted row keeps occupying the `(userId, slug)` uniqueness slot. So the INSERT collided and the whole migration aborted, failing the deploy's pre-deploy validation.

This is a latent bug: any bundled flow whose slug matches a soft-deleted row on a target blocks that deploy.

## Fix

The only correct way to re-install over a soft-deleted `(owner, slug)` is **restore + update**, not insert. `installCatalogEntry` now:

1. After `resolveSlug` returns `null`, checks for a soft-deleted row via the new `WorkflowRepository.resolveSlugIncludingDeleted()`.
2. If found, `restore()`s it and falls through to the existing version-gated update path (`save()` un-deletes on update).

Catalog install is idempotent and a bundled flow is meant to exist on the target, so resurrecting it is the intended behavior.

## Tests

Adds two integration tests in `workflow-catalog-loader.test.ts`:
- restore + update when the bundled version is newer,
- restore when the bundled version is unchanged.

Full integration suite: 477 passed. Typecheck + eslint clean.

## Notes

Encountered in production: two public flows (`software-development-flow-lite`, `startup-idea-validation`) had their canonical `system-moira` rows soft-deleted while `system-admin` duplicates stayed active. With this fix the deploy cleanly restored + updated them (`1.1.1 → 1.2.2`, `1.2.1 → 1.3.2`).

https://claude.ai/code/session_01MGKsJsDiHQ4rmheWSM1GEY