### PR TITLE
docs(readme): add self-host Updating/Upgrading section

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,40 @@ The image is pulled from the public registry by default. Data (SQLite + executio
 storage) persists in `./data`. See [Self-Hosting](#self-host-recommended) or the in-app docs
 at `/docs/` for the full reference.
 
+### Updating / Upgrading
+
+A self-host upgrade is just an image swap — your data in `./data` is untouched:
+
+```bash
+docker compose pull        # fetch the new ghcr.io/moira-mcp/moira image
+docker compose up -d        # recreate the container on the new image
+```
+
+On **every** container start, before the app serves traffic, the entrypoint runs
+database migrations and a **version-gated** workflow-catalog sync. So upgrading the
+image automatically:
+
+- applies schema migrations to your existing database, and
+- updates the **bundled** system workflows whose version was bumped in the new release
+  — a higher `metadata.version` is re-installed in place, unchanged ones are skipped,
+  and a previously soft-deleted bundled flow is restored and updated.
+
+What is **preserved** across an upgrade:
+
+- your **own** workflows (created/edited in the Web UI) — never touched,
+- all execution history, notes, artifacts, settings, and accounts,
+- everything else in `./data` (a host bind-mount that survives container recreation).
+
+What **changes**:
+
+- only the **system bundled** workflows are brought up to the versions shipped in the
+  new image.
+
+To pin a specific version instead of tracking `latest`, set the tag in
+`docker-compose.yml`, e.g. `image: ghcr.io/moira-mcp/moira:0.4.0`. Per-version release
+notes and the changelog are on the
+[GitHub Releases](https://github.com/moira-mcp/moira/releases) page.
+
 ### Local Development (from source)
 
 For contributors who want to build and run from the source tree, switch


### PR DESCRIPTION
Adds a self-host **Updating / Upgrading** section to the README.

## What it documents
- Upgrade is an image swap: `docker compose pull && docker compose up -d` — `./data` untouched.
- On every container start, `init-database` runs migrations + a **version-gated** workflow-catalog sync before serving traffic, so bundled flow version bumps apply to the **existing** DB.
- Preserved: user-owned workflows, executions, notes, artifacts, settings, accounts, everything in `./data`.
- Changed: only system **bundled** workflows are brought to the new versions.
- Version pinning + link to GitHub Releases (changelog).

## Verification
Reproduced at the image level: a bundled flow bumped 1.2.0 → 1.2.1 in a new image started over a pre-existing DB updates **in place** (`Installed: 0 | Updated: 1`, same workflowId). Mirrors today's production deploy (1.1.1 → 1.2.2) on the live DB.

https://claude.ai/code/session_01MGKsJsDiHQ4rmheWSM1GEY