### PR TITLE
ci(release): semantic-release automation + versioned multi-arch publish

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -10,8 +10,18 @@ name: Publish Image
 # secret-free env file. Publishes the image only; it does not deploy anywhere.
 
 on:
+  # Primary path: called by release.yml after a semantic-release version is cut,
+  # to publish the versioned multi-arch image. `:latest` now tracks the latest
+  # release (not every master push). A tag created by release.yml's GITHUB_TOKEN
+  # does NOT re-trigger workflows, which is why this is invoked via workflow_call.
+  workflow_call:
+    inputs:
+      version:
+        description: "Release version to tag the image with (e.g. 0.4.0)"
+        required: true
+        type: string
+  # Manual safety paths: a human pushing a v* tag, or a manual dispatch.
   push:
-    branches: [master]
     tags: ["v*"]
   workflow_dispatch:
 
@@ -105,16 +115,30 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # Under workflow_call the context is the caller's branch ref (refs/heads/master),
+      # so the `type=semver` lines below produce NOTHING — derive the version tags
+      # explicitly from the input instead. `minor` = version with the patch dropped
+      # (0.4.1 -> 0.4).
+      - name: Derive version tags
+        id: ver
+        if: ${{ inputs.version != '' }}
+        run: |
+          V='${{ inputs.version }}'
+          echo "full=$V"       >> "$GITHUB_OUTPUT"
+          echo "minor=${V%.*}" >> "$GITHUB_OUTPUT"
+
       - name: Extract image metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
+            type=raw,value=${{ steps.ver.outputs.full }},enable=${{ inputs.version != '' }}
+            type=raw,value=${{ steps.ver.outputs.minor }},enable=${{ inputs.version != '' }}
+            type=raw,value=latest,enable=${{ inputs.version != '' }}
+            type=sha
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Log in to GHCR
@@ -133,4 +157,4 @@ jobs:
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.version || steps.meta.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release
+
+# Automated releases via semantic-release (Conventional Commits).
+#
+# On every push to master (i.e. a merged PR), the `release` job analyzes commits
+# since the last tag and, if there is a releasable change (fix/feat/breaking),
+# creates a git tag `v<version>` + a GitHub Release with generated notes. It does
+# NOT push any commit back to master (tags-only) — so it needs no bypass of branch
+# protection and the default GITHUB_TOKEN suffices.
+#
+# The `publish` job then builds + pushes the versioned multi-arch GHCR image by
+# calling publish-image.yml as a reusable workflow with the computed version.
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: semantic-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the git tag + GitHub Release
+      issues: write
+      pull-requests: write
+    outputs:
+      published: ${{ steps.semantic.outputs.new_release_published }}
+      version: ${{ steps.semantic.outputs.new_release_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history so commit analysis sees all tags
+
+      - name: semantic-release
+        id: semantic
+        uses: cycjimmy/semantic-release-action@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: Publish versioned image
+    needs: release
+    if: needs.release.outputs.published == 'true'
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/publish-image.yml
+    with:
+      version: ${{ needs.release.outputs.version }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,15 @@
+{
+  "branches": ["master"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/github",
+      {
+        "successComment": false,
+        "failComment": false,
+        "labels": false
+      }
+    ]
+  ]
+}


### PR DESCRIPTION
Automated releases for moira-mcp/moira via **semantic-release** (Conventional Commits), tags + GitHub Release only.

## What this PR adds
- **`.releaserc.json`** — plugins `commit-analyzer` + `release-notes-generator` + `github` (no `npm`/`git` → no commit-back to master, no extra secrets). Changelog = GitHub Release notes.
- **`.github/workflows/release.yml`** — on push to `master`: `release` job runs `cycjimmy/semantic-release-action@v6` (outputs `published`/`version`), creating tag `v<version>` + a GitHub Release; `publish` job (`needs: release`, if published) calls `publish-image.yml` via `workflow_call` with the version.
- **`.github/workflows/publish-image.yml`** *(in this PR)* — add `workflow_call(version)`, version-tag the multi-arch image via `type=raw`, remove the `push:[master]` trigger so `:latest` tracks the latest release. _(added in a follow-up commit on this branch)_

## Why tags-only
A git tag + GitHub Release targets `refs/tags/*`, which branch protection on `master` does not block — so the default `GITHUB_TOKEN` works with no PAT/App/bypass and no DCO conflict (no bot commit to master).

## Behavior change
After this lands, **only releases publish images**; `:latest` = latest stable release. Non-release master pushes (docs/chore) no longer publish `:latest`/`:master`/`:sha` (intentional; prod infra deploys build locally and are unaffected).

## Secrets required
None.

https://claude.ai/code/session_01MGKsJsDiHQ4rmheWSM1GEY