### PR TITLE
ci: move flaky E2E out of the PR gate into a nightly workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,18 +1,22 @@
-name: CI
+name: E2E (nightly)
+
+# End-to-end (Playwright) tests are flaky on shared CI runners, so they are kept
+# OUT of the PR gate (ci.yml) and run here instead: nightly on a schedule, and
+# on-demand via workflow_dispatch. A failure here does NOT block any PR merge —
+# it is a signal to investigate, not a gate.
 
 on:
-  push:
-    branches: [master]
-  pull_request:
-    branches: [master]
+  schedule:
+    - cron: "0 3 * * *" # 03:00 UTC daily
+  workflow_dispatch:
 
 env:
   DOCKER_IMAGE: mcp-moira-ci
   DOCKER_PORT: 3030
 
 jobs:
-  lint:
-    name: Lint and Format
+  e2e:
+    name: E2E Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,91 +30,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run ESLint
-        run: npx eslint .
-
-      - name: Run Prettier
-        run: npx prettier --check .
-
-  unit-tests:
-    name: Unit Tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Setup env file
-        run: cp .env.ci .env
-
-      - name: Run unit tests
-        run: npm run test:unit
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: unit-test-results
-          path: test-results/
-          retention-days: 7
-
-  integration-tests:
-    name: Integration Tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Setup env file
-        run: |
-          cp .env.ci .env
-          # Override DB_PATH for integration tests
-          echo "DB_PATH=./data/test-integration.db" >> .env
-
-      - name: Create data directory
-        run: mkdir -p data
-
-      - name: Run integration tests
-        run: npm run test:integration
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: integration-test-results
-          path: test-results/
-          retention-days: 7
-
-  docker-build-and-test:
-    name: Docker Build & API Tests
-    runs-on: ubuntu-latest
-    needs: [lint, unit-tests, integration-tests]
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
 
       - name: Setup env files
         run: |
@@ -172,29 +93,18 @@ jobs:
           sleep 5
           curl -f -s http://localhost:6274 > /dev/null && echo "MCP Inspector is ready!" || echo "MCP Inspector may not be ready yet"
 
-      - name: Run API tests
-        run: npm run test:api
+      - name: Run E2E tests
+        run: npm run test:e2e
         env:
           CI: true
           TEST_BASE_URL: http://localhost:${{ env.DOCKER_PORT }}
 
-      - name: Run MCP tools tests
-        run: npm run test:mcp-tools
-        env:
-          CI: true
-          TEST_BASE_URL: http://localhost:${{ env.DOCKER_PORT }}
-
-      # E2E (Playwright) tests are flaky on shared CI runners and are NOT run on PRs.
-      # They run nightly + on-demand in .github/workflows/e2e.yml instead, so they
-      # never block a merge. See CONTRIBUTING.md "Releases & versioning".
-
-      - name: Upload test results
+      - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: docker-test-results
-          path: |
-            test-results/
+          name: playwright-report
+          path: playwright-report/
           retention-days: 7
 
       - name: Show container logs on failure


### PR DESCRIPTION
The Playwright **E2E** suite is flaky on shared CI runners and intermittently fails unrelated PRs (it timed out / failed on recent green-everything-else PRs). Move it out of the PR gate so it never blocks a merge.

## Changes
- **`ci.yml`** — the `docker-build-and-test` job is renamed **"Docker Build & API Tests"**; it still builds the image and runs **API + MCP-tools** tests, but the Playwright install + `test:e2e` step are removed.
- **`e2e.yml`** *(new)* — runs the full Docker build + E2E suite **nightly** (`cron 03:00 UTC`) and on-demand (`workflow_dispatch`). A failure here is a signal to investigate, not a merge gate.

## Effect
PR CI = Lint, Unit, Integration, Docker Build & API Tests (all reliably runnable). E2E still runs every night with the Playwright report uploaded as an artifact.

https://claude.ai/code/session_01MGKsJsDiHQ4rmheWSM1GEY