### PR TITLE
docs(contributing): releases/versioning section + fix stale docs path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,11 +65,11 @@ Releases are automated with [semantic-release](https://semantic-release.gitbook.
 driven by [Conventional Commits](https://www.conventionalcommits.org/). Write your
 commit subjects accordingly:
 
-| Commit type | Effect |
-| --- | --- |
-| `fix: …` | patch release (`0.0.X`) |
-| `feat: …` | minor release (`0.X.0`) |
-| `feat!: …` or a `BREAKING CHANGE:` footer | major release (`X.0.0`) |
+| Commit type                                        | Effect                  |
+| -------------------------------------------------- | ----------------------- |
+| `fix: …`                                           | patch release (`0.0.X`) |
+| `feat: …`                                          | minor release (`0.X.0`) |
+| `feat!: …` or a `BREAKING CHANGE:` footer          | major release (`X.0.0`) |
 | `docs:` / `chore:` / `refactor:` / `test:` / `ci:` | no release on their own |
 
 **How a release happens.** `master` is protected — there are no direct pushes, and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,35 @@ git commit -s -m "your message"
 
 This adds a `Signed-off-by: Your Name <your@email>` line to the commit message.
 
+## Releases & versioning
+
+Releases are automated with [semantic-release](https://semantic-release.gitbook.io/)
+driven by [Conventional Commits](https://www.conventionalcommits.org/). Write your
+commit subjects accordingly:
+
+| Commit type | Effect |
+| --- | --- |
+| `fix: …` | patch release (`0.0.X`) |
+| `feat: …` | minor release (`0.X.0`) |
+| `feat!: …` or a `BREAKING CHANGE:` footer | major release (`X.0.0`) |
+| `docs:` / `chore:` / `refactor:` / `test:` / `ci:` | no release on their own |
+
+**How a release happens.** `master` is protected — there are no direct pushes, and
+only the maintainer merges PRs. Each merge to `master` runs the **Release** workflow:
+semantic-release analyzes the commits since the last tag and, on a releasable change,
+creates a git tag `v<version>` and a **GitHub Release** with generated notes (this is
+the changelog). The release then publishes a versioned multi-arch image to
+`ghcr.io/moira-mcp/moira` — `:<version>`, `:<major>.<minor>`, and `:latest`. No
+secrets or manual steps are involved (the release uses only the built-in
+`GITHUB_TOKEN`; it creates tags/releases, never pushing to `master`).
+
+Self-host users upgrade simply by pulling the new image — see
+[Updating / Upgrading](README.md#updating--upgrading) in the README.
+
+**CI on pull requests** runs Lint, Unit, Integration, and a Docker build + API/MCP
+tests. The Playwright **E2E** suite is flaky on shared runners, so it runs nightly
+(and on demand) via `.github/workflows/e2e.yml` rather than gating PRs.
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under the
@@ -67,7 +96,7 @@ By contributing, you agree that your contributions will be licensed under the
 ## Documentation changes
 
 When modifying the public documentation under
-`packages/landing-page/src/content/docs/`:
+`packages/docs/src/content/docs/`:
 
 - [ ] Page exists in **both** languages: `docs/` (English) and `ru/docs/` (Russian)
 - [ ] Page is added to the sidebar configuration

--- a/README.md
+++ b/README.md
@@ -585,6 +585,12 @@ For contributors working on the codebase (implementation detail, not end-user do
 | Deployment             | Environment variables, restart procedures            | `docs/deployment/`                                                |
 | Legal                  | License/legal notes                                  | `docs/legal/`                                                     |
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, the PR flow, DCO sign-off, and how
+releases are automated (Conventional Commits → semantic-release → versioned GHCR
+image). For upgrading a self-host instance, see [Updating / Upgrading](#updating--upgrading).
+
 ## License
 
 [Apache License 2.0](LICENSE)


### PR DESCRIPTION
Extends the existing `CONTRIBUTING.md` (does not replace it) with the development + release process.

## Changes
- **CONTRIBUTING.md → new "Releases & versioning"**: Conventional Commits table (fix→patch, feat→minor, feat!/BREAKING→major), protected-`master` + owner-only-merge flow, the automated semantic-release pipeline (tag `v<version>` + GitHub Release notes = changelog + versioned multi-arch GHCR image, no secrets), the self-host upgrade link, and the nightly-E2E CI split.
- **CONTRIBUTING.md → fix stale path**: `packages/landing-page/src/content/docs/` → `packages/docs/src/content/docs/` (verified: only `packages/docs/...` exists).
- **README.md → Contributing section** linking CONTRIBUTING.md.

Note: the README `#updating--upgrading` anchor refers to the section added in #69 — both land together.

https://claude.ai/code/session_01MGKsJsDiHQ4rmheWSM1GEY