### PR TITLE
fix(self-host): generate real secrets over baked build placeholders

### DIFF
--- a/packages/shared/src/config/secrets-bootstrap.ts
+++ b/packages/shared/src/config/secrets-bootstrap.ts
@@ -36,6 +36,29 @@ export interface GeneratedSecret {
 const DB_PATH_DEFAULT = "./data/moira.db";
 const SECRETS_FILE_NAME = ".secrets.env";
 
+/**
+ * Build-time placeholder values baked into the public image's env file
+ * (`.env.selfhost` → `.env`) so the image BUILD doesn't fail, but which are NOT
+ * real secrets. They are deliberately non-empty, so at runtime they must be
+ * treated as "absent" — otherwise the auto-generated real secret is never
+ * written over them and a fresh self-host install boots with (or rejects) the
+ * public placeholder. Keep in sync with `config/.env.selfhost` and the
+ * weak-key check in `env.ts`.
+ */
+const BUILD_PLACEHOLDERS: Record<string, string> = {
+  BETTER_AUTH_SECRET: "public-image-build-placeholder-not-used-at-runtime",
+  TELEGRAM_ENCRYPTION_KEY: "0123456789abcdef".repeat(4),
+};
+
+/**
+ * A secret counts as "missing" (so it should be generated / overridden by a
+ * persisted value) when it is unset, empty, OR equal to the known build-time
+ * placeholder for that key. An operator-provided real value is never touched.
+ */
+export function needsSecret(key: string, value: string | undefined): boolean {
+  return value === undefined || value === "" || value === BUILD_PLACEHOLDERS[key];
+}
+
 /** Resolve the durable secrets file path, alongside the SQLite database. */
 export function getSecretsFilePath(): string {
   const dbPath = path.resolve(process.env.DB_PATH || DB_PATH_DEFAULT);
@@ -43,8 +66,9 @@ export function getSecretsFilePath(): string {
 }
 
 /**
- * Load persisted secrets into `process.env` WITHOUT overriding values already
- * set (explicit env / `.env` always wins over generated ones).
+ * Load persisted secrets into `process.env` WITHOUT overriding real
+ * operator-provided values (explicit env / `.env` always wins). A baked-in
+ * build placeholder is NOT a real value, so a persisted secret DOES override it.
  * No-op if the file does not exist.
  */
 export function loadPersistedSecrets(filePath: string = getSecretsFilePath()): void {
@@ -53,7 +77,7 @@ export function loadPersistedSecrets(filePath: string = getSecretsFilePath()): v
   }
   const parsed = dotenv.parse(fs.readFileSync(filePath));
   for (const [key, value] of Object.entries(parsed)) {
-    if (process.env[key] === undefined || process.env[key] === "") {
+    if (needsSecret(key, process.env[key])) {
       process.env[key] = value;
     }
   }
@@ -119,7 +143,9 @@ export function bootstrapSelfHostSecrets(
 
   const ensure = (key: string, gen: () => string, exposeValue = false): void => {
     const current = process.env[key];
-    if (current !== undefined && current !== "") {
+    // Reuse only a REAL operator-provided value; a baked build placeholder
+    // (or empty/unset) must be replaced with a freshly generated secret.
+    if (!needsSecret(key, current)) {
       results.push({ key, generated: false });
       return;
     }

--- a/scripts/init-database.sh
+++ b/scripts/init-database.sh
@@ -11,10 +11,25 @@ rm -f /tmp/init-success /tmp/init-failed
 /usr/local/bin/tsx scripts/bootstrap-secrets.ts \
   && /usr/local/bin/tsx scripts/run-migrations.ts \
   && /usr/local/bin/tsx scripts/migrate-workflows-in-docker.ts
+chain_rc=$?
 
-if [ $? -eq 0 ]; then
+# Defense-in-depth: a migration step can hit a fatal error yet still exit 0 — the
+# shared logger runs with exitOnError:false and swallows an uncaughtException
+# raised while the config singleton initializes at import time. So do NOT trust the
+# exit code alone: verify the database was actually initialized (schema present and
+# the bundled workflow catalog loaded) before declaring success. Without this guard
+# a broken init would write /tmp/init-success and supervisor would start the
+# services against an empty DB. If sqlite3 is unavailable, fall back to the exit code.
+db="${DB_PATH:-./data/moira.db}"
+schema_ok() {
+  command -v sqlite3 >/dev/null 2>&1 || return 0
+  [ "$(sqlite3 "$db" 'SELECT COUNT(*) FROM workflow;' 2>/dev/null || echo 0)" -gt 0 ]
+}
+
+if [ "$chain_rc" -eq 0 ] && schema_ok; then
     touch /tmp/init-success
 else
+    echo "init-database: FAILED (exit code $chain_rc; database not initialized)" >&2
     touch /tmp/init-failed
     exit 1
 fi

--- a/tests/unit/shared/secrets-bootstrap.test.ts
+++ b/tests/unit/shared/secrets-bootstrap.test.ts
@@ -134,5 +134,40 @@ describe("secrets-bootstrap", () => {
       expect(() => loadPersistedSecrets()).not.toThrow();
       expect(process.env.BETTER_AUTH_SECRET).toBeUndefined();
     });
+
+    it("overrides a baked build placeholder with the persisted real secret", () => {
+      // The public image bakes a non-empty placeholder into .env; a persisted
+      // real secret must win over it (otherwise the placeholder reaches config).
+      fs.writeFileSync(secretsFile, `TELEGRAM_ENCRYPTION_KEY=${"a".repeat(64)}\n`);
+      process.env.TELEGRAM_ENCRYPTION_KEY = "0123456789abcdef".repeat(4); // weak build placeholder
+
+      loadPersistedSecrets();
+
+      expect(process.env.TELEGRAM_ENCRYPTION_KEY).toBe("a".repeat(64));
+    });
+  });
+
+  describe("build placeholders are treated as missing", () => {
+    const AUTH_PLACEHOLDER = "public-image-build-placeholder-not-used-at-runtime";
+    const TELEGRAM_WEAK = "0123456789abcdef".repeat(4);
+
+    it("regenerates real secrets over the baked build placeholders", () => {
+      // Reproduces the self-host first-start bug: the image's .env sets these to
+      // non-empty placeholders, which must NOT be reused as real secrets.
+      process.env.DEPLOYMENT_MODE = "self-host";
+      process.env.BETTER_AUTH_SECRET = AUTH_PLACEHOLDER;
+      process.env.TELEGRAM_ENCRYPTION_KEY = TELEGRAM_WEAK;
+
+      const results = bootstrapSelfHostSecrets();
+
+      expect(results.find((x) => x.key === "BETTER_AUTH_SECRET")?.generated).toBe(true);
+      expect(results.find((x) => x.key === "TELEGRAM_ENCRYPTION_KEY")?.generated).toBe(true);
+      expect(process.env.BETTER_AUTH_SECRET).toMatch(/^[0-9a-f]{64}$/);
+      expect(process.env.TELEGRAM_ENCRYPTION_KEY).toMatch(/^[0-9a-f]{64}$/);
+      expect(process.env.BETTER_AUTH_SECRET).not.toBe(AUTH_PLACEHOLDER);
+      expect(process.env.TELEGRAM_ENCRYPTION_KEY).not.toBe(TELEGRAM_WEAK);
+      // And the generated values are persisted for reuse across restarts.
+      expect(fs.existsSync(secretsFile)).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Bug
A fresh **self-host** start with no operator-provided secrets fails: `init-database` aborts with `TELEGRAM_ENCRYPTION_KEY is weak`, leaving an **empty DB** — and (separately) services started anyway against it.

## Root cause
The public image bakes **non-empty placeholders** into `.env` (from `.env.selfhost`):
- `BETTER_AUTH_SECRET=public-image-build-placeholder-not-used-at-runtime`
- `TELEGRAM_ENCRYPTION_KEY=0123456789abcdef…` (the exact value `env.ts` rejects as "weak")

`bootstrapSelfHostSecrets()` / `loadPersistedSecrets()` only treated **unset/empty** values as "missing", so these placeholders were never regenerated/overridden → the weak key reached config validation and aborted init.

## Fix (two parts)
1. **`secrets-bootstrap.ts`** — add a build-placeholder registry + `needsSecret(key, value)` (missing = unset/empty/**known placeholder**), used in both the generate and load paths. Operator-provided real values are never touched.
2. **`init-database.sh`** — defense-in-depth: the shared logger runs `exitOnError:false`, so a fatal config error at import time is swallowed and a migration step can exit 0. Verify the DB was actually initialized (`COUNT(workflow) > 0`) before writing `/tmp/init-success`; otherwise write `/tmp/init-failed` + exit 1. (Falls back to the exit code if sqlite3 is absent.)

## Verification (clean installs, end-to-end in Docker)
- Unit suite: **1385 passed** (new placeholder tests included).
- **(a) no secrets** → SUCCESS, `TELEGRAM_ENCRYPTION_KEY: generated (256-bit)`, 32 flows, healthy/HTTP 200.
- **(b) restart over same DB** → SUCCESS, secrets **reused** ("already present — nothing generated"), 32 flows (idempotent).
- **(c) operator-provided secrets** → SUCCESS, operator values used, 32 flows.
- **(d) saas mode + no secrets** → correctly **FAILS** via the guard (no false `init-success`) instead of starting on an empty DB.

https://claude.ai/code/session_01MGKsJsDiHQ4rmheWSM1GEY