### PR TITLE
fix(workflows): ignore catalog metadata in content checks

### DIFF
--- a/packages/shared/src/services/workflow-catalog.ts
+++ b/packages/shared/src/services/workflow-catalog.ts
@@ -89,7 +89,13 @@ export function readCatalogEntry(filePath: string): CatalogEntry {
   }
 
   // The graph body excludes the catalog-only metadata keys.
-  const { owner: _owner, visibility: _visibility, previousSlugs: _previousSlugs, ...graph } = raw;
+  const {
+    slug: _slug,
+    owner: _owner,
+    visibility: _visibility,
+    previousSlugs: _previousSlugs,
+    ...graph
+  } = raw;
 
   return {
     id: typeof raw.id === "string" ? raw.id : path.basename(filePath, ".json"),

--- a/packages/shared/src/utils/version-utils.ts
+++ b/packages/shared/src/utils/version-utils.ts
@@ -97,13 +97,15 @@ export function normalizeWorkflowForComparison(workflow: unknown): string {
     return "undefined";
   }
 
-  const normalize = (obj: unknown): unknown => {
+  const catalogMetadataKeys = new Set(["slug", "owner", "visibility", "previousSlugs"]);
+
+  const normalize = (obj: unknown, depth = 0): unknown => {
     if (obj === null || obj === undefined) {
       return obj;
     }
 
     if (Array.isArray(obj)) {
-      return obj.map(normalize);
+      return obj.map((value) => normalize(value, depth + 1));
     }
 
     if (typeof obj === "object") {
@@ -112,6 +114,13 @@ export function normalizeWorkflowForComparison(workflow: unknown): string {
       const normalized: Record<string, unknown> = {};
 
       for (const key of sortedKeys) {
+        // Catalog identity and ownership live in dedicated database columns. Legacy uploads may
+        // also contain these fields at the graph root, so they must not create a false content
+        // mismatch during an idempotent catalog load. Same-named nested graph data remains
+        // significant.
+        if (depth === 0 && catalogMetadataKeys.has(key)) {
+          continue;
+        }
         // Skip version field in metadata
         if (key === "version") {
           continue;
@@ -124,7 +133,7 @@ export function normalizeWorkflowForComparison(workflow: unknown): string {
         if (key === "createdAt" || key === "updatedAt") {
           continue;
         }
-        normalized[key] = normalize(record[key]);
+        normalized[key] = normalize(record[key], depth + 1);
       }
 
       return normalized;

--- a/tests/COVERAGE-MAP.md
+++ b/tests/COVERAGE-MAP.md
@@ -5,7 +5,7 @@ Agents MUST update this file when adding, moving, or deleting tests.
 
 ## Summary
 
-- **40 domains**, **267 files**, **3369 tests**
+- **40 domains**, **267 files**, **3372 tests**
 - Levels: unit, integration, workflow, api, mcp-tools, e2e, functional
 
 ## Domain Overview
@@ -32,7 +32,7 @@ Agents MUST update this file when adding, moving, or deleting tests.
 | help-system         | 1     | 26    | unit:1                                                          |
 | http-infrastructure | 5     | 62    | api:2, unit:3                                                   |
 | i18n                | 11    | 100   | e2e:10, unit:1                                                  |
-| infrastructure      | 4     | 87    | unit:4                                                          |
+| infrastructure      | 4     | 88    | unit:4                                                          |
 | input-parsing       | 4     | 60    | functional:1, integration:1, mcp-tools:1, unit:1                |
 | inspector           | 1     | 1     | e2e:1                                                           |
 | mcp-clients         | 2     | 50    | e2e:1, unit:1                                                   |
@@ -55,7 +55,7 @@ Agents MUST update this file when adding, moving, or deleting tests.
 | user-management     | 3     | 34    | api:1, e2e:2                                                    |
 | validation          | 4     | 90    | api:1, integration:1, unit:2                                    |
 | web-ui              | 7     | 41    | e2e:5, unit:2                                                   |
-| workflow-engine     | 69    | 924   | api:4, e2e:7, integration:14, mcp-tools:5, unit:11, workflow:28 |
+| workflow-engine     | 69    | 926   | api:4, e2e:7, integration:14, mcp-tools:5, unit:11, workflow:28 |
 | workflow-scenarios  | 25    | 167   | workflow:25                                                     |
 
 ## Domain Details
@@ -413,7 +413,7 @@ Agents MUST update this file when adding, moving, or deleting tests.
 
 - `tests/unit/scripts/detect-test-env.test.ts` — 8 tests 🟢
 - `tests/unit/scripts/remigrate-registry-schemas.test.ts` — 31 tests 🟢 (registry schema restoration: strengthen type-guard, mergeOldSchemas safe merge/union/absence-unbounded/items-properties-reconcile/required-intersection, gate-enum inference, collectExpressionTargets counter-guard, bumpMinor)
-- `tests/unit/shared/version-utils.test.ts` — 32 tests 🟢
+- `tests/unit/shared/version-utils.test.ts` — 33 tests 🟢 (including root-only catalog metadata normalization without masking nested graph content)
 
 ### input-parsing
 
@@ -788,7 +788,7 @@ Agents MUST update this file when adding, moving, or deleting tests.
 - `tests/unit/web-backend/execution-materialize.test.ts` — 5 tests 🟢 (current-definition fetch, execution binding, tar response, one-use endpoint behavior, non-consumption on render overflow, and expected-4xx versus unexpected-boundary error mapping)
 - `tests/unit/logging/compute-changes.test.ts` — 11 tests 🟢
 - `tests/unit/shared/workflow-query-service.test.ts` — 45 tests 🟢 (incl. setWorkflowVariable preserves rich schema)
-- `tests/unit/shared/workflow-catalog.test.ts` — 18 tests 🟢 (+ readWorkflowCatalogs multi-dir merge: union, later-dir-wins precedence on (owner,slug) collision, per-owner duplicate slugs preserved, missing/empty dirs skipped, single-dir == readWorkflowCatalog; + getWorkflowsDirs config: default, WORKFLOWS_DIR fallback, colon-separated WORKFLOWS_DIRS, empty-segment drop)
+- `tests/unit/shared/workflow-catalog.test.ts` — 19 tests 🟢 (catalog identity/ownership metadata is excluded from the executable graph; readWorkflowCatalogs multi-dir merge: union, later-dir-wins precedence on (owner,slug) collision, per-owner duplicate slugs preserved, missing/empty dirs skipped, single-dir == readWorkflowCatalog; getWorkflowsDirs config: default, WORKFLOWS_DIR fallback, colon-separated WORKFLOWS_DIRS, empty-segment drop)
 - `tests/unit/web-frontend/workflow-transformer.test.ts` — 20 tests 🟢 (including materialize registration on the shared CompactNode, factory output, frontend validation boundaries, content-free file summary data, success/error edge styling, and no fallback warning)
 - `tests/unit/workflow-engine/variable-resolver.test.ts` — 9 tests 🟢
 - `tests/unit/workflow-engine/registry-converter.test.ts` — 13 tests 🟢
@@ -799,7 +799,7 @@ Agents MUST update this file when adding, moving, or deleting tests.
 
 - `tests/integration/workflow-file-tokens.test.ts` — 13 tests 🟢 (upload/download lifecycle plus five-minute materialize TTL boundary, real SQLite grant-failure normalization, user/execution/node binding, and atomic one-use claim)
 - `tests/integration/agent-response-contract.test.ts` — 3 tests 🟢
-- `tests/integration/workflow-catalog-loader.test.ts` — 13 tests 🟢 (owner/visibility mapping, version-aware idempotence, missing owners, content mismatch, cross-owner isolation, soft-deleted restoration, explicit previous-slug migration without duplicate catalog entries, and multi-directory merge/install behavior)
+- `tests/integration/workflow-catalog-loader.test.ts` — 14 tests 🟢 (owner/visibility mapping, version-aware idempotence including persisted legacy root catalog metadata, missing owners, content mismatch, cross-owner isolation, soft-deleted restoration, explicit previous-slug migration without duplicate catalog entries, and multi-directory merge/install behavior)
 - `tests/integration/database/workflow-privacy-defaults.test.ts` — 2 tests 🟡
 - `tests/integration/manage-workflow-actions.test.ts` — 32 tests 🟢
 - `tests/integration/manage-workflow-new-actions.test.ts` — 29 tests 🟢

--- a/tests/integration/workflow-catalog-loader.test.ts
+++ b/tests/integration/workflow-catalog-loader.test.ts
@@ -128,6 +128,30 @@ describe("Workflow Catalog Loader Integration", () => {
     expect(second.outcomes[0].outcome).toBe("skipped-unchanged");
   });
 
+  test("treats legacy root catalog metadata in a persisted graph as unchanged", async () => {
+    const slug = `loader-legacy-metadata-${Date.now()}`;
+    const catalogEntry = entry(OWNER_A, slug, "1.0.0");
+
+    await deps.mutationService.save({
+      graph: {
+        ...catalogEntry.graph,
+        slug,
+        owner: OWNER_A,
+        visibility: "public",
+      },
+      userId: OWNER_A,
+      slug,
+      visibility: "public",
+      skipAudit: true,
+    });
+
+    const result = await installCatalogEntries([catalogEntry], deps);
+    expect(result.installed).toBe(0);
+    expect(result.updated).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.outcomes[0].outcome).toBe("skipped-unchanged");
+  });
+
   test("skips and reports a flow whose owner does not exist, never reassigning to a system owner", async () => {
     const slug = `loader-missing-owner-${Date.now()}`;
     const result = await installCatalogEntries([entry(MISSING_OWNER, slug, "1.0.0")], deps);

--- a/tests/unit/shared/version-utils.test.ts
+++ b/tests/unit/shared/version-utils.test.ts
@@ -239,6 +239,29 @@ describe("Version Utilities", () => {
 
       expect(hasWorkflowContentChanged(workflow1, workflow2)).toBe(true);
     });
+
+    it("ignores catalog metadata at the graph root but preserves nested fields", () => {
+      const persistedLegacyGraph = {
+        slug: "demo-flow",
+        owner: "system-moira",
+        visibility: "public",
+        previousSlugs: ["old-demo-flow"],
+        metadata: { name: "test", version: "1.0.0" },
+        nodes: [{ id: "1", config: { owner: "runtime-owner" } }],
+      };
+      const catalogGraph = {
+        metadata: { name: "test", version: "1.0.0" },
+        nodes: [{ id: "1", config: { owner: "runtime-owner" } }],
+      };
+
+      expect(hasWorkflowContentChanged(persistedLegacyGraph, catalogGraph)).toBe(false);
+      expect(
+        hasWorkflowContentChanged(persistedLegacyGraph, {
+          ...catalogGraph,
+          nodes: [{ id: "1", config: { owner: "different-runtime-owner" } }],
+        }),
+      ).toBe(true);
+    });
   });
 
   describe("Migration scenario: same version, different content", () => {

--- a/tests/unit/shared/workflow-catalog.test.ts
+++ b/tests/unit/shared/workflow-catalog.test.ts
@@ -74,6 +74,7 @@ describe("Workflow Catalog Reader", () => {
       expect(entry.visibility).toBe("public");
       expect(entry.isSystemOwner).toBe(true);
       // Graph body excludes catalog-only metadata.
+      expect("slug" in entry.graph).toBe(false);
       expect("owner" in entry.graph).toBe(false);
       expect("visibility" in entry.graph).toBe(false);
       expect("nodes" in entry.graph).toBe(true);


### PR DESCRIPTION
## Summary
- exclude all catalog-only identity and ownership fields from executable catalog graphs
- ignore legacy root catalog metadata during version-aware content comparison while preserving nested graph fields
- cover the production-shaped persisted graph regression and update the coverage map

## Production diagnosis
The pre-deploy copy validation rejected system-moira/software-development-flow 12.8.0 because its persisted graph contains legacy root owner and visibility fields, while readCatalogEntry correctly removes those catalog-only fields before comparison. The exported executable content is otherwise identical.

## Verification
- npm run test:unit: 1419/1419 passed
- npm run test:integration: 483/483 passed
- npx eslint .: 0 errors (1 unrelated existing hook warning)
- npx prettier --check .: passed