### PR TITLE
fix(self-host): safeguard compose updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 #
 # Self-host quickstart (pull-first — no source build needed):
 #   cp .env.example .env
-#   docker compose up -d        # pulls the immutable MOIRA_IMAGE pin below
+#   docker compose up -d        # pulls the current public image below
 #   open http://localhost:8080
 #
 # For a LOCALHOST run you can leave this file UNCHANGED — the defaults below work
@@ -15,8 +15,9 @@
 # REQUIRED VARIABLES (host-dependent — keep ports consistent)
 # ============================================
 
-# Immutable image pin used by docker-compose and the upgrade helper.
-MOIRA_IMAGE=ghcr.io/moira-mcp/moira:0.3.5
+# Public self-host image. `docker compose pull` fetches the current release;
+# image startup automatically protects an existing SQLite database before migration.
+MOIRA_IMAGE=ghcr.io/moira-mcp/moira:latest
 
 # Public host (REQUIRED). Host only, protocol auto-detected: localhost=http, else=https.
 # Must match MOIRA_PORT below and STATIC_ARTIFACTS_DOMAIN. Examples: localhost:8080, moira.example.com

--- a/README.md
+++ b/README.md
@@ -70,30 +70,27 @@ at `/docs/` for the full reference.
 
 ### Updating / Upgrading
 
-Use an immutable version tag or digest and the shipped upgrade helper. The helper creates and
-verifies a coherent SQLite backup, runs the exact incoming image against an isolated copy, and only
-then replaces the container:
+Update a normal self-host installation with the standard Compose commands:
 
 ```bash
-./scripts/self-host-upgrade.sh backup ghcr.io/moira-mcp/moira:0.3.6
-./scripts/self-host-upgrade.sh preflight ghcr.io/moira-mcp/moira:0.3.6
-./scripts/self-host-upgrade.sh upgrade ghcr.io/moira-mcp/moira:0.3.6
+docker compose pull
+docker compose up -d
+docker compose ps
 ```
 
-Preflight mounts production data read-only and retains its snapshot and conflict evidence under
-`.moira-upgrade/`. If it reports managed-workflow reconciliation, keep the active instance running,
-use Workflow Management Flow to semantically merge the previous/current/incoming candidates, and
-retry the same pinned image. Do not use `--force` to discard local workflow changes.
+Older `.env` files may still override Compose with the removed `0.3.5` tag; change that line once to
+`MOIRA_IMAGE=ghcr.io/moira-mcp/moira:latest` before updating.
 
-If replacement or health verification fails after preflight, restore the verified database and
-previous image pin:
+The image protects existing self-host data before its startup migrations: it creates and verifies a
+coherent SQLite backup, includes the prompt manifest, and keeps three rotating recovery states under
+`data/.moira-startup-backups/`. If initialization fails, it restores the database and manifest before
+refusing to start the services. A persistent pending marker also restores the verified state before the
+next attempt if the container or host was interrupted mid-initialization. A fresh installation skips
+the nonexistent-database backup and uses only a temporary persistent marker so an interrupted first
+start is removed before retry.
 
-```bash
-./scripts/self-host-upgrade.sh rollback
-```
-
-The complete procedure, prerequisites, space/permission checks, version inspection, and recovery
-contract are in [Self-hosting: Safe Upgrade and Rollback](packages/docs/src/content/docs/docs/getting-started/self-hosting.mdx#safe-upgrade-and-rollback), with a matching [Russian version](packages/docs/src/content/docs/ru/docs/getting-started/self-hosting.mdx#безопасное-обновление-и-откат). Release notes are on the [GitHub Releases](https://github.com/moira-mcp/moira/releases) page.
+The complete automatic recovery behavior and optional pinned-image preflight are documented in
+[Self-hosting: Updating and Recovery](packages/docs/src/content/docs/docs/getting-started/self-hosting.mdx#updating-and-recovery), with a matching [Russian version](packages/docs/src/content/docs/ru/docs/getting-started/self-hosting.mdx#обновление-и-восстановление). Release notes are on the [GitHub Releases](https://github.com/moira-mcp/moira/releases) page.
 
 ### Local Development (from source)
 

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -148,7 +148,14 @@ COPY drizzle.config.ts ./
 COPY workflows/ ./workflows/
 
 # Make health check scripts executable
-RUN chmod +x ./scripts/health-check.sh ./scripts/startup-ready.sh ./scripts/wait-for-init.sh ./scripts/init-database.sh
+RUN chmod +x \
+    ./scripts/health-check.sh \
+    ./scripts/startup-ready.sh \
+    ./scripts/wait-for-init.sh \
+    ./scripts/init-database.sh \
+    ./scripts/container-entrypoint.sh \
+    ./scripts/self-host-startup-guard.sh \
+    ./scripts/sqlite-online-backup.sh
 
 # Setup nginx for static files. Web UI dist destination depends on APP_BASE_PATH:
 #   "/"    (self-host) → /var/www/html/      (Web UI at root, no brand landing)
@@ -205,5 +212,6 @@ EXPOSE 80 9090
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
     CMD curl -f http://localhost:9090/health || exit 1
 
-# Start supervisor directly
+# Reset the per-container startup generation before Supervisor can spawn waiters.
+ENTRYPOINT ["/app/scripts/container-entrypoint.sh"]
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/config/supervisord.conf
+++ b/config/supervisord.conf
@@ -15,13 +15,15 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 # Run database migrations on startup (MUST succeed before services start)
 [program:init-database]
-command=/app/scripts/init-database.sh
+command=/app/scripts/self-host-startup-guard.sh /app/scripts/init-database.sh
 directory=/app
 user=root
 autostart=true
 autorestart=false
 startsecs=0
 exitcodes=0
+stopasgroup=true
+killasgroup=true
 priority=10
 redirect_stderr=true
 stdout_logfile=/var/log/supervisor/init-database.log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,9 @@ services:
     # --- Option A: use the prebuilt public image (DEFAULT) ---
     # Pulled from GHCR — no source checkout or local build needed. This is the
     # recommended self-host path: `cp .env.example .env` then `docker compose up -d`.
-    image: ${MOIRA_IMAGE:-ghcr.io/moira-mcp/moira:0.3.5}
+    # Update later with `docker compose pull` followed by `docker compose up -d`;
+    # image startup protects the mounted SQLite state before migrations.
+    image: ${MOIRA_IMAGE:-ghcr.io/moira-mcp/moira:latest}
 
     # --- Option B: build the image locally from source (advanced) ---
     # For contributors / customizers only. Requires the full source tree.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -210,6 +210,7 @@ tests/integration/  # Workflow execution tests
 scripts/
 ├── run-migrations.ts         # Drizzle ORM migrations
 ├── migrate-workflows-in-docker.ts  # Workflow JSON → DB migration
+├── self-host-startup-guard.sh # Automatic self-host DB/manifest backup and failure restore
 ├── init-database.sh          # Migration wrapper with sentinel files
 └── wait-for-init.sh          # Service startup gate (polls for sentinel)
 ```
@@ -456,10 +457,22 @@ All services run inside single Docker container managed by supervisord:
 **Service Startup Order:**
 
 ```
-init-database (priority 10) → sentinel file → services (priority 50)
+container-entrypoint → Supervisor → self-host-startup-guard → init-database → sentinel → services
 ```
 
-`scripts/init-database.sh` runs DB migrations first, writes `/tmp/init-success` on completion. All services (`mcp-server`, `backend-api`, `nginx`) wait for this sentinel via `scripts/wait-for-init.sh` before starting. If migrations fail, `/tmp/init-failed` is written and services refuse to start.
+`scripts/container-entrypoint.sh` clears stale terminal sentinels before Supervisor exists, so a
+same-container restart cannot admit a waiter from the previous run. Supervisor then invokes
+`scripts/self-host-startup-guard.sh` before `scripts/init-database.sh`. In
+self-host mode, an existing SQLite database and its prompt manifest are copied coherently into three
+rotating slots under `data/.moira-startup-backups/`; a failed initialization restores that state, and
+a persistent pending marker recovers an interrupted initialization before the next backup. First start
+uses a marker without a fake DB backup so failure or interruption removes its incomplete state. SaaS
+bypasses this guard because its copied-DB preflight
+and swap are owned by deployment infrastructure. In self-host mode the outer guard exclusively owns
+both terminal sentinels: it clears stale values before backup, suppresses child publication, commits
+`/tmp/init-success` only after the recovery marker transitions to committed, and publishes
+`/tmp/init-failed` only after restore. All services (`mcp-server`,
+`backend-api`, `nginx`) wait through `scripts/wait-for-init.sh`; `/tmp/init-failed` keeps them stopped.
 
 ### Request Flow
 

--- a/packages/docs/src/content/docs/docs/getting-started/self-hosting.mdx
+++ b/packages/docs/src/content/docs/docs/getting-started/self-hosting.mdx
@@ -11,24 +11,17 @@ image from the registry — no source checkout or local build needed.
 ## Prerequisites
 
 - Docker with the Compose plugin (`docker compose`)
-- Host `sqlite3` CLI (used to verify preflight and rollback snapshots)
-- The self-host release bundle files: `docker-compose.yml`, `.env.example`, and
-  executable `scripts/self-host-upgrade.sh` (download the same release tag from the repository;
-  no source build or private repository is required)
+- The public `docker-compose.yml` and `.env.example`; no source build, private repository,
+  host SQLite CLI, or separate upgrade script is required for the normal path
 
 ## Quick Start
 
-Download the three files from one immutable release tag (replace `0.3.5` when selecting another
-release):
+Download the current public self-host files:
 
 ```bash
-MOIRA_VERSION=0.3.5
-MOIRA_RELEASE=https://raw.githubusercontent.com/moira-mcp/moira/v${MOIRA_VERSION}
-curl -fLO "$MOIRA_RELEASE/docker-compose.yml"
-curl -fLo .env.example "$MOIRA_RELEASE/.env.example"
-mkdir -p scripts
-curl -fLo scripts/self-host-upgrade.sh "$MOIRA_RELEASE/scripts/self-host-upgrade.sh"
-chmod +x scripts/self-host-upgrade.sh
+MOIRA_FILES=https://raw.githubusercontent.com/moira-mcp/moira/master
+curl -fLO "$MOIRA_FILES/docker-compose.yml"
+curl -fLo .env.example "$MOIRA_FILES/.env.example"
 ```
 
 <Steps>
@@ -47,8 +40,8 @@ chmod +x scripts/self-host-upgrade.sh
     docker compose up -d
     ```
 
-    Compose pulls the immutable `MOIRA_IMAGE` from `.env` (the shipped example pins
-    `ghcr.io/moira-mcp/moira:0.3.5`) and starts the container.
+    Compose pulls `ghcr.io/moira-mcp/moira:latest`, the current public release, and starts
+    the container.
 
 3.  **Open the Web UI**
 
@@ -213,46 +206,77 @@ http://localhost:8080/mcp
 Add it as an MCP server in your AI client and complete OAuth authentication. See
 [Quick Start](/docs/getting-started/quickstart/) for client configuration.
 
-## Safe Upgrade and Rollback
+## Updating and Recovery
 
-Keep an immutable image pin in `.env` (a version or digest, never `latest`):
-
-```bash
-MOIRA_IMAGE=ghcr.io/moira-mcp/moira:0.3.5
-docker compose pull moira
-docker compose exec -T moira cat /app/BUILD_INFO
-df -h ./data && test -r ./data/moira.db && test -w ./data
-```
-
-The shipped helper uses SQLite online backup and verifies `PRAGMA integrity_check` before it changes
-the active container:
+The ordinary update path does not require a version lookup or a repository-side helper:
 
 ```bash
-./scripts/self-host-upgrade.sh backup ghcr.io/moira-mcp/moira:0.3.6
-./scripts/self-host-upgrade.sh preflight ghcr.io/moira-mcp/moira:0.3.6
-./scripts/self-host-upgrade.sh upgrade ghcr.io/moira-mcp/moira:0.3.6
-docker compose ps && docker compose exec -T moira cat /app/BUILD_INFO
-```
-
-Preflight mounts production data read-only, writes its verified snapshot/evidence under
-`.moira-upgrade/`, and runs the exact incoming image against `.moira-upgrade/preflight/moira.db`,
-never the production DB.
-If it reports managed-workflow reconciliation, the active instance stays available. Ask your agent
-to run Workflow Management Flow, inspect the MCP `reconciliation` tool's previous/current/incoming
-candidates, submit the semantic merge, and retry the pinned upgrade. Do not use `--force` to discard
-local workflow changes.
-
-If replacement or health verification fails, restore the verified snapshot and previous pin:
-
-```bash
-./scripts/self-host-upgrade.sh rollback
+docker compose pull
+docker compose up -d
 docker compose ps
-docker compose exec -T moira sqlite3 /app/data/moira.db 'PRAGMA integrity_check;'
 ```
 
-Keep `.moira-upgrade/moira.db.upgrade-backup` until the new version has been verified. The helper
-preserves `.moira-upgrade/preflight/` as diagnostic/reconciliation evidence and replaces it on the
-next preflight.
+If an existing `.env` came from the older broken template and still contains the removed `0.3.5`
+tag, change it once before updating:
+
+```bash
+MOIRA_IMAGE=ghcr.io/moira-mcp/moira:latest
+```
+
+Before the new self-host image runs migrations against an existing database, its startup guard uses
+SQLite online backup and verifies `PRAGMA integrity_check`. It stores the database and matching
+`prompt-manifest.json` under `data/.moira-startup-backups/current/`, rotating the prior states to
+`previous-1/` and `previous-2/`. A genuine first start has no database to back up.
+
+The current slot carries a persistent initialization-pending marker. If the container or host is killed
+before initialization commits, the next start restores that verified slot before creating a new
+backup, so a partially migrated database cannot become the next baseline.
+On the first start, a marker without a fake database backup records that no database existed. An
+interrupted retry removes only the incomplete new database, WAL/SHM, and prompt manifest before
+starting clean; successful initialization removes the marker.
+
+If schema, prompt, or workflow initialization fails after writing data, the guard removes WAL/SHM,
+restores the verified database and prompt manifest, writes `/tmp/init-failed`, and keeps MCP, the API,
+and nginx stopped. The recovery copy remains available. Inspect and retry after correcting the
+configuration or catalog:
+
+```bash
+docker compose logs moira
+docker compose exec -T moira sqlite3 /app/data/moira.db 'PRAGMA integrity_check;'
+docker compose exec -T moira sqlite3 /app/data/.moira-startup-backups/current/moira.db 'PRAGMA integrity_check;'
+docker compose restart moira
+docker compose ps
+```
+
+`latest` intentionally follows the current public release. Automatic recovery protects persistent
+data; it cannot replace the Docker image itself. If the image cannot reach the startup guard, the
+database has not been migrated. Temporarily set `MOIRA_IMAGE` to a previous version from
+[GitHub Releases](https://github.com/moira-mcp/moira/releases), run `docker compose up -d`, and return
+to `latest` after a corrected release.
+
+Managed-workflow reconciliation conflicts remain non-fatal in self-host mode. Use
+Workflow Management Flow and the MCP `reconciliation` tool to inspect previous/current/incoming
+candidates and submit a semantic merge; do not use `--force` to discard local changes.
+
+### Optional preflight before downtime
+
+Operators who want to test an exact image on an isolated database copy before replacing the active
+container may download the advanced helper from that release. This is optional; normal updates use
+the two Compose commands above. The host `sqlite3` CLI is required only for this advanced path.
+
+```bash
+RELEASE_VERSION=x.y.z
+TARGET_IMAGE=ghcr.io/moira-mcp/moira:${RELEASE_VERSION}
+curl -fLo self-host-upgrade.sh "https://raw.githubusercontent.com/moira-mcp/moira/v${RELEASE_VERSION}/scripts/self-host-upgrade.sh"
+chmod +x self-host-upgrade.sh
+./self-host-upgrade.sh preflight "$TARGET_IMAGE"
+./self-host-upgrade.sh upgrade "$TARGET_IMAGE"
+```
+
+The helper retains its verified snapshot and diagnostic copy under `.moira-upgrade/`; use
+`./self-host-upgrade.sh rollback` if its replacement or health check fails. Because this advanced
+path writes the exact image to `.env`, set `MOIRA_IMAGE=ghcr.io/moira-mcp/moira:latest` afterward if
+you want to rejoin the normal release channel.
 
 ## Adding Your Own Workflow Flows
 

--- a/packages/docs/src/content/docs/ru/docs/getting-started/self-hosting.mdx
+++ b/packages/docs/src/content/docs/ru/docs/getting-started/self-hosting.mdx
@@ -11,24 +11,17 @@ import { Aside, Steps } from "@astrojs/starlight/components";
 ## Требования
 
 - Docker с плагином Compose (`docker compose`)
-- CLI `sqlite3` на хосте (для проверки preflight и rollback snapshot)
-- Файлы self-host release bundle: `docker-compose.yml`, `.env.example` и исполняемый
-  `scripts/self-host-upgrade.sh` (скачайте их из того же release tag репозитория;
-  сборка исходников и private-репозиторий не нужны)
+- Публичные `docker-compose.yml` и `.env.example`; для обычного пути не нужны сборка
+  исходников, private-репозиторий, CLI SQLite на хосте или отдельный upgrade-скрипт
 
 ## Быстрый старт
 
-Скачайте три файла из одного неизменяемого release tag (замените `0.3.5`, если выбираете другой
-релиз):
+Скачайте актуальные публичные self-host файлы:
 
 ```bash
-MOIRA_VERSION=0.3.5
-MOIRA_RELEASE=https://raw.githubusercontent.com/moira-mcp/moira/v${MOIRA_VERSION}
-curl -fLO "$MOIRA_RELEASE/docker-compose.yml"
-curl -fLo .env.example "$MOIRA_RELEASE/.env.example"
-mkdir -p scripts
-curl -fLo scripts/self-host-upgrade.sh "$MOIRA_RELEASE/scripts/self-host-upgrade.sh"
-chmod +x scripts/self-host-upgrade.sh
+MOIRA_FILES=https://raw.githubusercontent.com/moira-mcp/moira/master
+curl -fLO "$MOIRA_FILES/docker-compose.yml"
+curl -fLo .env.example "$MOIRA_FILES/.env.example"
 ```
 
 <Steps>
@@ -47,8 +40,8 @@ chmod +x scripts/self-host-upgrade.sh
     docker compose up -d
     ```
 
-    Compose скачивает неизменяемый `MOIRA_IMAGE` из `.env` (в поставляемом примере указан
-    `ghcr.io/moira-mcp/moira:0.3.5`) и запускает контейнер.
+    Compose скачивает `ghcr.io/moira-mcp/moira:latest`, актуальный публичный релиз,
+    и запускает контейнер.
 
 3.  **Откройте веб-интерфейс**
 
@@ -216,45 +209,77 @@ http://localhost:8080/mcp
 Добавьте его как MCP-сервер в ваш AI-клиент и пройдите OAuth-аутентификацию. Настройку
 клиента смотрите в [Быстром старте](/ru/docs/getting-started/quickstart/).
 
-## Безопасное обновление и откат
+## Обновление и восстановление
 
-Храните в `.env` неизменяемый pin образа — версию или digest, но не `latest`:
-
-```bash
-MOIRA_IMAGE=ghcr.io/moira-mcp/moira:0.3.5
-docker compose pull moira
-docker compose exec -T moira cat /app/BUILD_INFO
-df -h ./data && test -r ./data/moira.db && test -w ./data
-```
-
-Поставляемый helper использует online backup SQLite и проверяет `PRAGMA integrity_check` до замены
-активного контейнера:
+Для обычного обновления не требуется искать версию или запускать скрипт из репозитория:
 
 ```bash
-./scripts/self-host-upgrade.sh backup ghcr.io/moira-mcp/moira:0.3.6
-./scripts/self-host-upgrade.sh preflight ghcr.io/moira-mcp/moira:0.3.6
-./scripts/self-host-upgrade.sh upgrade ghcr.io/moira-mcp/moira:0.3.6
-docker compose ps && docker compose exec -T moira cat /app/BUILD_INFO
-```
-
-Preflight монтирует production data read-only, пишет snapshot/evidence в `.moira-upgrade/` и запускает
-точный входящий образ только на `.moira-upgrade/preflight/moira.db`, не на production БД.
-При конфликте managed workflow активный экземпляр остаётся доступным. Попросите агента запустить
-Workflow Management Flow, изучить previous/current/incoming кандидаты MCP-инструмента
-`reconciliation`, отправить семантическое слияние и повторить обновление с pin. Не используйте
-`--force` для удаления локальных изменений workflow.
-
-Если замена или health-проверка завершилась ошибкой, восстановите проверенный snapshot и прежний pin:
-
-```bash
-./scripts/self-host-upgrade.sh rollback
+docker compose pull
+docker compose up -d
 docker compose ps
-docker compose exec -T moira sqlite3 /app/data/moira.db 'PRAGMA integrity_check;'
 ```
 
-Сохраняйте `.moira-upgrade/moira.db.upgrade-backup` до проверки новой версии. Helper оставляет
-`.moira-upgrade/preflight/` как диагностическое/reconciliation-доказательство и заменяет его при следующем
-preflight.
+Если существующий `.env` создан из старого сломанного шаблона и всё ещё содержит удалённый тег
+`0.3.5`, один раз замените строку перед обновлением:
+
+```bash
+MOIRA_IMAGE=ghcr.io/moira-mcp/moira:latest
+```
+
+До запуска миграций нового self-host образа startup guard создаёт online backup существующей SQLite
+БД и проверяет `PRAGMA integrity_check`. База вместе с соответствующим `prompt-manifest.json`
+сохраняется в `data/.moira-startup-backups/current/`, а предыдущие состояния ротируются в
+`previous-1/` и `previous-2/`. При настоящем первом запуске БД ещё нет, поэтому backup не создаётся.
+
+В current-слоте хранится persistent-маркер незавершённой инициализации. Если контейнер или хост
+прерывается до фиксации результата, следующий запуск сначала восстанавливает проверенный slot и
+только затем создаёт новый backup, поэтому частично мигрированная БД не становится новым baseline.
+На первом запуске отдельный marker без фиктивной backup-БД фиксирует, что базы раньше не было. После
+прерывания повторный запуск удаляет только незавершённые новую БД, WAL/SHM и prompt manifest и
+начинает с чистого состояния; успешная инициализация удаляет marker.
+
+Если инициализация схемы, промптов или workflow завершается ошибкой после записи данных, guard
+удаляет WAL/SHM, восстанавливает проверенные БД и manifest, пишет `/tmp/init-failed` и не запускает
+MCP, API и nginx. Recovery-копия сохраняется. После исправления конфигурации или каталога проверьте
+состояние и повторите запуск:
+
+```bash
+docker compose logs moira
+docker compose exec -T moira sqlite3 /app/data/moira.db 'PRAGMA integrity_check;'
+docker compose exec -T moira sqlite3 /app/data/.moira-startup-backups/current/moira.db 'PRAGMA integrity_check;'
+docker compose restart moira
+docker compose ps
+```
+
+`latest` намеренно следует за текущим публичным релизом. Автоматическое восстановление защищает
+постоянные данные, но не может заменить сам Docker-образ. Если образ не доходит до startup guard,
+БД не мигрировалась. Временно укажите в `MOIRA_IMAGE` предыдущую версию из
+[GitHub Releases](https://github.com/moira-mcp/moira/releases), выполните `docker compose up -d`,
+а после исправленного релиза вернитесь на `latest`.
+
+Конфликты сверки managed workflow остаются нефатальными в self-host. Используйте
+Workflow Management Flow и MCP-инструмент `reconciliation`, чтобы изучить previous/current/incoming
+кандидаты и отправить семантическое слияние; не применяйте `--force` для удаления локальных изменений.
+
+### Необязательный preflight до остановки
+
+Оператор может заранее проверить точный образ на изолированной копии БД, скачав advanced helper из
+этого релиза. Это необязательный путь; обычное обновление использует две Compose-команды выше. CLI
+`sqlite3` на хосте нужен только для advanced-варианта.
+
+```bash
+RELEASE_VERSION=x.y.z
+TARGET_IMAGE=ghcr.io/moira-mcp/moira:${RELEASE_VERSION}
+curl -fLo self-host-upgrade.sh "https://raw.githubusercontent.com/moira-mcp/moira/v${RELEASE_VERSION}/scripts/self-host-upgrade.sh"
+chmod +x self-host-upgrade.sh
+./self-host-upgrade.sh preflight "$TARGET_IMAGE"
+./self-host-upgrade.sh upgrade "$TARGET_IMAGE"
+```
+
+Helper сохраняет проверенный snapshot и диагностическую копию в `.moira-upgrade/`; если замена или
+health check завершились ошибкой, используйте `./self-host-upgrade.sh rollback`. Advanced-путь
+записывает точный образ в `.env`; чтобы вернуться в обычный release channel, после проверки задайте
+`MOIRA_IMAGE=ghcr.io/moira-mcp/moira:latest`.
 
 ## Добавление собственных workflow-флоу
 

--- a/scripts/container-entrypoint.sh
+++ b/scripts/container-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Establish a fresh startup generation before Supervisor can spawn any waiter.
+set -eu
+
+sentinel_dir=${MOIRA_INIT_SENTINEL_DIR:-/tmp}
+[ -d "$sentinel_dir" ] && [ ! -L "$sentinel_dir" ] || {
+  echo "ERROR: initialization sentinel directory is unavailable or unsafe: $sentinel_dir" >&2
+  exit 1
+}
+
+rm -f -- "$sentinel_dir/init-success" "$sentinel_dir/init-failed"
+[ ! -e "$sentinel_dir/init-success" ] && [ ! -L "$sentinel_dir/init-success" ]
+[ ! -e "$sentinel_dir/init-failed" ] && [ ! -L "$sentinel_dir/init-failed" ]
+
+exec "$@"

--- a/scripts/init-database.sh
+++ b/scripts/init-database.sh
@@ -3,8 +3,13 @@
 # On success: writes /tmp/init-success
 # On failure: writes /tmp/init-failed and exits with code 1
 
-# Clean up stale sentinel files from previous container runs
-rm -f /tmp/init-success /tmp/init-failed
+# The outer self-host startup guard owns both sentinels so it can publish a
+# terminal state only after backup commit or failure restoration. Direct/SaaS
+# invocations retain this script's standalone sentinel behavior.
+sentinel_owner=${MOIRA_INIT_SENTINEL_OWNER:-self}
+if [ "$sentinel_owner" != "guard" ]; then
+    rm -f /tmp/init-success /tmp/init-failed || exit 1
+fi
 
 # First-start secret bootstrap (self-host): generate missing secrets before
 # migrations so a fresh install boots without manual .env editing.
@@ -27,9 +32,13 @@ schema_ok() {
 }
 
 if [ "$chain_rc" -eq 0 ] && schema_ok; then
-    touch /tmp/init-success
+    if [ "$sentinel_owner" != "guard" ]; then
+        touch /tmp/init-success || exit 1
+    fi
 else
     echo "init-database: FAILED (exit code $chain_rc; database not initialized)" >&2
-    touch /tmp/init-failed
+    if [ "$sentinel_owner" != "guard" ]; then
+        touch /tmp/init-failed || true
+    fi
     exit 1
 fi

--- a/scripts/self-host-startup-guard.sh
+++ b/scripts/self-host-startup-guard.sh
@@ -1,0 +1,367 @@
+#!/bin/sh
+# Protect self-host persistent startup state before database initialization.
+set -u
+
+SENTINEL_DIR=${MOIRA_INIT_SENTINEL_DIR:-/tmp}
+INIT_FAILED="$SENTINEL_DIR/init-failed"
+INIT_SUCCESS="$SENTINEL_DIR/init-success"
+NEXT=""
+SUCCESS_NEXT=""
+DB_RESTORE_TEMP=""
+MANIFEST_RESTORE_TEMP=""
+CHILD_PID=""
+
+present() {
+  [ -e "$1" ] || [ -L "$1" ]
+}
+
+remove_file() {
+  path=$1
+  rm -f -- "$path" || return 1
+  ! present "$path"
+}
+
+publish_failure() {
+  touch "$INIT_FAILED" || {
+    echo "ERROR: cannot publish initialization failure sentinel: $INIT_FAILED" >&2
+    return 1
+  }
+}
+
+fail() {
+  echo "ERROR: $*" >&2
+  publish_failure || true
+  exit 1
+}
+
+[ -d "$SENTINEL_DIR" ] && [ ! -L "$SENTINEL_DIR" ] \
+  || {
+    echo "ERROR: initialization sentinel directory is unavailable or unsafe: $SENTINEL_DIR" >&2
+    exit 1
+  }
+remove_file "$INIT_SUCCESS" && remove_file "$INIT_FAILED" \
+  || {
+    echo "ERROR: cannot clear stale initialization sentinels" >&2
+    exit 1
+  }
+
+[ "$#" -gt 0 ] || fail "startup command is required"
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+MODE=$(printf '%s' "${DEPLOYMENT_MODE:-self-host}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
+if [ "$MODE" != "self-host" ]; then
+  exec "$@"
+fi
+
+DB=${DB_PATH:-./data/moira.db}
+DB_DIR=$(dirname "$DB")
+DB_NAME=$(basename "$DB")
+MANIFEST="$DB_DIR/prompt-manifest.json"
+STATE_DIR="$DB_DIR/.moira-startup-backups"
+CURRENT="$STATE_DIR/current"
+PREVIOUS_1="$STATE_DIR/previous-1"
+PREVIOUS_2="$STATE_DIR/previous-2"
+FIRST_START="$STATE_DIR/first-start"
+HAD_DB=0
+
+[ ! -L "$DB" ] || fail "database path may not be a symlink: $DB"
+[ ! -L "$MANIFEST" ] || fail "prompt manifest may not be a symlink: $MANIFEST"
+[ ! -L "$STATE_DIR" ] || fail "startup backup path may not be a symlink: $STATE_DIR"
+
+validate_regular_or_absent() {
+  path=$1
+  ! present "$path" || { [ -f "$path" ] && [ ! -L "$path" ]; }
+}
+
+validate_slot() {
+  slot=$1
+  ! present "$slot" || { [ -d "$slot" ] && [ ! -L "$slot" ]; } || return 1
+  [ ! -d "$slot" ] || {
+    validate_regular_or_absent "$slot/$DB_NAME" \
+      && validate_regular_or_absent "$slot/$DB_NAME-wal" \
+      && validate_regular_or_absent "$slot/$DB_NAME-shm" \
+      && validate_regular_or_absent "$slot/prompt-manifest.json" \
+      && validate_regular_or_absent "$slot/prompt-manifest.absent" \
+      && validate_regular_or_absent "$slot/initialization.pending" \
+      && validate_regular_or_absent "$slot/initialization.committed" \
+      && validate_regular_or_absent "$slot/first-start.pending" \
+      && validate_regular_or_absent "$slot/first-start.committed"
+  }
+}
+
+remove_slot() {
+  slot=$1
+  validate_slot "$slot" || return 1
+  remove_file "$slot/$DB_NAME" \
+    && remove_file "$slot/$DB_NAME-wal" \
+    && remove_file "$slot/$DB_NAME-shm" \
+    && remove_file "$slot/prompt-manifest.json" \
+    && remove_file "$slot/prompt-manifest.absent" \
+    && remove_file "$slot/initialization.pending" \
+    && remove_file "$slot/initialization.committed" \
+    && remove_file "$slot/first-start.pending" \
+    && remove_file "$slot/first-start.committed" \
+    || return 1
+  [ ! -d "$slot" ] || rmdir "$slot"
+}
+
+remove_staging_dir() {
+  staging=$1
+  [ -d "$staging" ] && [ ! -L "$staging" ] || return 1
+  case "$staging" in "$STATE_DIR"/.next.*) ;; *) return 1 ;; esac
+  rm -rf -- "$staging" || return 1
+  ! present "$staging"
+}
+
+cleanup_staging() {
+  [ -z "$NEXT" ] || ! present "$NEXT" || remove_staging_dir "$NEXT" || true
+  [ -z "$SUCCESS_NEXT" ] || remove_file "$SUCCESS_NEXT" || true
+  [ -z "$DB_RESTORE_TEMP" ] || remove_file "$DB_RESTORE_TEMP" || true
+  [ -z "$MANIFEST_RESTORE_TEMP" ] || remove_file "$MANIFEST_RESTORE_TEMP" || true
+}
+abort_before_mutation() {
+  trap - HUP INT TERM
+  cleanup_staging
+  publish_failure || true
+  trap - EXIT
+  exit 1
+}
+trap cleanup_staging EXIT
+trap abort_before_mutation HUP INT TERM
+
+mkdir -p "$STATE_DIR" || fail "cannot create startup backup directory: $STATE_DIR"
+[ -d "$STATE_DIR" ] && [ ! -L "$STATE_DIR" ] \
+  || fail "startup backup directory is unavailable or unsafe: $STATE_DIR"
+
+for stale in "$STATE_DIR"/.next.*; do
+  present "$stale" || continue
+  remove_staging_dir "$stale" || fail "cannot remove unsafe or stale startup staging path: $stale"
+done
+
+for stale in "$DB_DIR"/.moira-db-restore.* "$DB_DIR"/.moira-manifest-restore.*; do
+  present "$stale" || continue
+  [ -f "$stale" ] && [ ! -L "$stale" ] \
+    || fail "unsafe stale restore path: $stale"
+  remove_file "$stale" || fail "cannot remove stale restore file: $stale"
+done
+
+for slot in "$CURRENT" "$PREVIOUS_1" "$PREVIOUS_2" "$FIRST_START"; do
+  validate_slot "$slot" || fail "unsafe startup recovery slot: $slot"
+done
+
+if [ -f "$CURRENT/initialization.committed" ]; then
+  remove_file "$CURRENT/initialization.committed" \
+    || fail "cannot clear committed initialization marker"
+fi
+if [ -f "$FIRST_START/first-start.committed" ]; then
+  remove_slot "$FIRST_START" || fail "cannot clear committed first-start marker"
+fi
+
+restore_slot() {
+  slot=$1
+  backup="$slot/$DB_NAME"
+  validate_slot "$slot" && [ -f "$backup" ] && [ ! -L "$backup" ] || return 1
+  sqlite3 "$backup" "PRAGMA integrity_check;" | grep -qx ok || return 1
+  remove_file "$backup-wal" && remove_file "$backup-shm" || return 1
+  DB_RESTORE_TEMP=$(mktemp "$DB_DIR/.moira-db-restore.XXXXXX") || return 1
+  [ -f "$DB_RESTORE_TEMP" ] && [ ! -L "$DB_RESTORE_TEMP" ] || return 1
+  cp "$backup" "$DB_RESTORE_TEMP" || return 1
+  [ -f "$DB_RESTORE_TEMP" ] && [ ! -L "$DB_RESTORE_TEMP" ] || return 1
+  sqlite3 "$DB_RESTORE_TEMP" "PRAGMA integrity_check;" | grep -qx ok || {
+    remove_file "$DB_RESTORE_TEMP" || true
+    DB_RESTORE_TEMP=""
+    return 1
+  }
+
+  remove_file "$DB-wal" && remove_file "$DB-shm" || return 1
+  mv -f "$DB_RESTORE_TEMP" "$DB" || return 1
+  DB_RESTORE_TEMP=""
+  [ -f "$DB" ] && [ ! -L "$DB" ] || return 1
+
+  if [ -f "$slot/prompt-manifest.absent" ]; then
+    remove_file "$MANIFEST" || return 1
+  else
+    [ -f "$slot/prompt-manifest.json" ] && [ ! -L "$slot/prompt-manifest.json" ] || return 1
+    MANIFEST_RESTORE_TEMP=$(mktemp "$DB_DIR/.moira-manifest-restore.XXXXXX") || return 1
+    [ -f "$MANIFEST_RESTORE_TEMP" ] && [ ! -L "$MANIFEST_RESTORE_TEMP" ] || return 1
+    cp "$slot/prompt-manifest.json" "$MANIFEST_RESTORE_TEMP" || return 1
+    [ -f "$MANIFEST_RESTORE_TEMP" ] && [ ! -L "$MANIFEST_RESTORE_TEMP" ] || return 1
+    mv -f "$MANIFEST_RESTORE_TEMP" "$MANIFEST" || return 1
+    MANIFEST_RESTORE_TEMP=""
+  fi
+
+  sqlite3 "$DB" "PRAGMA integrity_check;" | grep -qx ok || return 1
+  remove_file "$backup-wal" && remove_file "$backup-shm" || return 1
+  echo "STARTUP_RESTORE_OK $DB" >&2
+}
+
+restore_first_start_state() {
+  validate_slot "$FIRST_START" || return 1
+  { [ -f "$FIRST_START/first-start.pending" ] \
+      || [ -f "$FIRST_START/first-start.committed" ]; } \
+    || return 1
+  remove_file "$DB" && remove_file "$DB-wal" && remove_file "$DB-shm" || return 1
+  ! present "$DB" && ! present "$DB-wal" && ! present "$DB-shm" || return 1
+  if [ -f "$FIRST_START/prompt-manifest.absent" ]; then
+    remove_file "$MANIFEST" || return 1
+  else
+    [ -f "$FIRST_START/prompt-manifest.json" ] \
+      && [ ! -L "$FIRST_START/prompt-manifest.json" ] || return 1
+    MANIFEST_RESTORE_TEMP=$(mktemp "$DB_DIR/.moira-manifest-restore.XXXXXX") || return 1
+    [ -f "$MANIFEST_RESTORE_TEMP" ] && [ ! -L "$MANIFEST_RESTORE_TEMP" ] || return 1
+    cp "$FIRST_START/prompt-manifest.json" "$MANIFEST_RESTORE_TEMP" || return 1
+    mv -f "$MANIFEST_RESTORE_TEMP" "$MANIFEST" || return 1
+    MANIFEST_RESTORE_TEMP=""
+  fi
+  remove_slot "$FIRST_START" || return 1
+  rmdir "$STATE_DIR" 2>/dev/null || true
+  echo "INTERRUPTED_FIRST_START_RECOVERED $DB" >&2
+}
+
+[ ! -f "$FIRST_START/first-start.pending" ] \
+  || [ ! -f "$CURRENT/initialization.pending" ] \
+  || fail "ambiguous interrupted startup markers"
+
+if [ -f "$FIRST_START/first-start.pending" ]; then
+  restore_first_start_state \
+    || fail "interrupted first-start state could not be removed safely"
+  mkdir -p "$STATE_DIR" || fail "cannot recreate startup backup directory"
+fi
+
+if [ -f "$CURRENT/initialization.pending" ]; then
+  restore_slot "$CURRENT" \
+    || fail "previous initialization was interrupted and its recovery backup could not be restored"
+  remove_file "$CURRENT/initialization.pending" \
+    || fail "cannot clear recovered initialization marker"
+  echo "INTERRUPTED_STARTUP_RECOVERED $CURRENT/$DB_NAME" >&2
+fi
+
+if [ -f "$DB" ]; then
+  HAD_DB=1
+  NEXT=$(mktemp -d "$STATE_DIR/.next.XXXXXX") \
+    || fail "cannot create startup backup staging directory"
+  [ -d "$NEXT" ] && [ ! -L "$NEXT" ] || fail "unsafe startup backup staging directory"
+
+  "$SCRIPT_DIR/sqlite-online-backup.sh" "$DB" "$NEXT/$DB_NAME" \
+    || fail "refusing startup because the existing database could not be backed up"
+  [ -f "$NEXT/$DB_NAME" ] && [ ! -L "$NEXT/$DB_NAME" ] \
+    || fail "startup backup was not published as a regular file"
+
+  if [ -f "$MANIFEST" ]; then
+    cp "$MANIFEST" "$NEXT/prompt-manifest.json" || fail "cannot back up prompt manifest"
+    [ -f "$NEXT/prompt-manifest.json" ] && [ ! -L "$NEXT/prompt-manifest.json" ] \
+      || fail "prompt manifest backup is unsafe"
+  else
+    touch "$NEXT/prompt-manifest.absent" || fail "cannot record absent prompt manifest"
+  fi
+
+  remove_slot "$PREVIOUS_2" || fail "cannot remove oldest startup backup"
+  [ ! -d "$PREVIOUS_1" ] || mv "$PREVIOUS_1" "$PREVIOUS_2" \
+    || fail "cannot rotate previous startup backup"
+  [ ! -d "$CURRENT" ] || mv "$CURRENT" "$PREVIOUS_1" \
+    || fail "cannot rotate current startup backup"
+  mv "$NEXT" "$CURRENT" || fail "cannot publish current startup backup"
+  NEXT=""
+  touch "$CURRENT/initialization.pending" || fail "cannot mark initialization as pending"
+  echo "STARTUP_BACKUP_OK $CURRENT/$DB_NAME"
+else
+  [ ! -d "$FIRST_START" ] || remove_slot "$FIRST_START" \
+    || fail "cannot reset first-start recovery slot"
+  mkdir "$FIRST_START" || fail "cannot create first-start recovery marker"
+  if [ -f "$MANIFEST" ]; then
+    cp "$MANIFEST" "$FIRST_START/prompt-manifest.json" \
+      || fail "cannot protect existing prompt manifest before first database start"
+  else
+    touch "$FIRST_START/prompt-manifest.absent" \
+      || fail "cannot record absent first-start prompt manifest"
+  fi
+  touch "$FIRST_START/first-start.pending" \
+    || fail "cannot mark first-start initialization as pending"
+fi
+
+restore_previous_state() {
+  if [ "$HAD_DB" -eq 0 ]; then
+    restore_first_start_state || return 1
+    echo "STARTUP_RESTORE_OK removed incomplete first-start state" >&2
+    return 0
+  fi
+  restore_slot "$CURRENT" || return 1
+  remove_file "$CURRENT/initialization.pending" \
+    && remove_file "$CURRENT/initialization.committed"
+}
+
+terminal_failure() {
+  if ! restore_previous_state; then
+    echo "ERROR: initialization failed and automatic state restore failed" >&2
+    echo "Recovery state retained under: $STATE_DIR" >&2
+  fi
+  publish_failure || true
+}
+
+handle_signal() {
+  trap - HUP INT TERM
+  [ -z "$CHILD_PID" ] || kill -TERM "$CHILD_PID" 2>/dev/null || true
+  [ -z "$CHILD_PID" ] || wait "$CHILD_PID" 2>/dev/null || true
+  CHILD_PID=""
+  terminal_failure
+  cleanup_staging
+  trap - EXIT
+  exit 1
+}
+
+trap handle_signal HUP INT TERM
+MOIRA_INIT_SENTINEL_OWNER=guard "$@" &
+CHILD_PID=$!
+wait "$CHILD_PID"
+init_rc=$?
+CHILD_PID=""
+trap 'cleanup_staging; exit 1' HUP INT TERM
+
+if [ "$init_rc" -ne 0 ]; then
+  terminal_failure
+  trap - EXIT HUP INT TERM
+  exit "$init_rc"
+fi
+
+SUCCESS_NEXT=$(mktemp "$SENTINEL_DIR/.init-success.XXXXXX") \
+  || {
+    terminal_failure
+    trap - EXIT HUP INT TERM
+    exit 1
+  }
+
+if [ "$HAD_DB" -eq 0 ]; then
+  mv "$FIRST_START/first-start.pending" "$FIRST_START/first-start.committed" \
+    || {
+      terminal_failure
+      trap - EXIT HUP INT TERM
+      exit 1
+    }
+else
+  mv "$CURRENT/initialization.pending" "$CURRENT/initialization.committed" \
+    || {
+      terminal_failure
+      trap - EXIT HUP INT TERM
+      exit 1
+    }
+fi
+
+if ! mv -f "$SUCCESS_NEXT" "$INIT_SUCCESS"; then
+  SUCCESS_NEXT=""
+  terminal_failure
+  trap - EXIT HUP INT TERM
+  exit 1
+fi
+SUCCESS_NEXT=""
+
+if [ "$HAD_DB" -eq 0 ]; then
+  remove_slot "$FIRST_START" \
+    || echo "WARNING: committed first-start marker will be cleaned on next startup" >&2
+else
+  remove_file "$CURRENT/initialization.committed" \
+    || echo "WARNING: committed initialization marker will be cleaned on next startup" >&2
+fi
+rmdir "$STATE_DIR" 2>/dev/null || true
+
+trap - EXIT HUP INT TERM
+exit 0

--- a/tests/COVERAGE-MAP.md
+++ b/tests/COVERAGE-MAP.md
@@ -18,8 +18,9 @@ level headings classify the tracked test paths listed beneath them.
 
 - `tests/unit/config/docker-image-contract.test.ts` — canonical parameterized OSS runtime image contract, explicit non-secret compile-time inputs, and prohibition on embedding deployment env files
 - `tests/unit/scripts/sqlite-online-backup.test.ts` — coherent SQLite online backup under concurrent WAL writes, integrity verification, and missing-source fail-closed behavior
-- `tests/unit/scripts/self-host-upgrade-contract.test.ts` — immutable image pins, isolated preflight, degraded self-host conflict policy, guarded replacement, health check, and backup-compatible rollback
-- `tests/unit/docs/self-host-upgrade-docs.test.ts` — executable EN/RU upgrade command parity, helper/sqlite prerequisites, quick-start immutable-pin consistency with Compose/env example, reconciliation recovery, integrity verification, and rollback instructions
+- `tests/unit/scripts/self-host-startup-guard.test.ts` — pre-Supervisor generation reset, real SQLite success, stale/ordered terminal sentinels, partial-init restore, interrupted existing/first-start recovery, removal/marker/sentinel faults, staging/restore symlink rejection, SIGTERM/SIGKILL recovery, prompt-manifest integrity, and bounded rotation including WAL sidecars
+- `tests/unit/scripts/self-host-upgrade-contract.test.ts` — latest-image quickstart, image-owned startup-guard wiring, plus optional pinned-image isolated preflight, health check, and rollback
+- `tests/unit/docs/self-host-upgrade-docs.test.ts` — executable EN/RU `pull`/`up` parity, automatic recovery location and semantics, latest consistency across Compose/env, and optional advanced preflight guidance
 - `tests/unit/scripts/test-email.test.ts` — explicit-recipient refusal and validation plus captured
   provider-boundary request for an IANA-reserved recipient
 

--- a/tests/unit/config/docker-image-contract.test.ts
+++ b/tests/unit/config/docker-image-contract.test.ts
@@ -21,6 +21,7 @@ describe("OSS image contract", () => {
     expect(dockerfile).toContain("ARG APP_BASE_PATH=/");
     expect(dockerfile).toContain("ARG MOIRA_HOST=localhost:8080");
     expect(dockerfile).toContain("ARG STATIC_ARTIFACTS_DOMAIN=static.localhost:8080");
+    expect(dockerfile).toContain('ENTRYPOINT ["/app/scripts/container-entrypoint.sh"]');
   });
 
   test("does not accept or embed a deployment environment file", () => {

--- a/tests/unit/docs/self-host-upgrade-docs.test.ts
+++ b/tests/unit/docs/self-host-upgrade-docs.test.ts
@@ -13,18 +13,18 @@ describe("self-host upgrade documentation parity", () => {
   );
   const envExample = readFileSync(resolve(".env.example"), "utf8");
   const compose = readFileSync(resolve("docker-compose.yml"), "utf8");
+  const readme = readFileSync(resolve("README.md"), "utf8");
   const commands = [
-    "MOIRA_IMAGE=ghcr.io/moira-mcp/moira:0.3.5",
-    "MOIRA_VERSION=0.3.5",
-    'curl -fLO "$MOIRA_RELEASE/docker-compose.yml"',
-    'curl -fLo scripts/self-host-upgrade.sh "$MOIRA_RELEASE/scripts/self-host-upgrade.sh"',
-    "chmod +x scripts/self-host-upgrade.sh",
-    "docker compose exec -T moira cat /app/BUILD_INFO",
-    "df -h ./data && test -r ./data/moira.db && test -w ./data",
-    "./scripts/self-host-upgrade.sh backup ghcr.io/moira-mcp/moira:0.3.6",
-    "./scripts/self-host-upgrade.sh preflight ghcr.io/moira-mcp/moira:0.3.6",
-    "./scripts/self-host-upgrade.sh upgrade ghcr.io/moira-mcp/moira:0.3.6",
-    "./scripts/self-host-upgrade.sh rollback",
+    "docker compose pull",
+    "docker compose up -d",
+    "docker compose ps",
+    "docker compose logs moira",
+    "docker compose restart moira",
+    "/app/data/.moira-startup-backups/current/moira.db",
+    "RELEASE_VERSION=x.y.z",
+    './self-host-upgrade.sh preflight "$TARGET_IMAGE"',
+    './self-host-upgrade.sh upgrade "$TARGET_IMAGE"',
+    "./self-host-upgrade.sh rollback",
     "PRAGMA integrity_check;",
   ];
 
@@ -33,24 +33,27 @@ describe("self-host upgrade documentation parity", () => {
     expect(russian).toContain(command);
   });
 
-  test("documents reconciliation recovery and immutable pins in both languages", () => {
+  test("documents automatic recovery and optional advanced preflight in both languages", () => {
     for (const document of [english, russian]) {
       expect(document).toContain("Workflow Management Flow");
       expect(document).toContain("reconciliation");
-      expect(
-        document.slice(
-          0,
-          document.indexOf("## Safe Upgrade") > 0
-            ? document.indexOf("## Safe Upgrade")
-            : document.indexOf("## Безопасное обновление"),
-        ),
-      ).not.toContain(":latest");
-      expect(document).toContain(".moira-upgrade/preflight/");
-      expect(document).toContain("scripts/self-host-upgrade.sh");
-      expect(document).toContain("sqlite3");
+      expect(document).toContain("data/.moira-startup-backups/current/");
+      expect(document).toContain("previous-1/");
+      expect(document).toContain("previous-2/");
+      expect(document).toContain("/tmp/init-failed");
+      expect(document).toContain("ghcr.io/moira-mcp/moira:latest");
+      expect(document).toContain("self-host-upgrade.sh");
     }
-    expect(envExample).not.toContain("pulls ghcr.io/moira-mcp/moira:latest");
-    expect(envExample).toContain("MOIRA_IMAGE=ghcr.io/moira-mcp/moira:0.3.5");
-    expect(compose).toContain("${MOIRA_IMAGE:-ghcr.io/moira-mcp/moira:0.3.5}");
+    expect(envExample).toContain("MOIRA_IMAGE=ghcr.io/moira-mcp/moira:latest");
+    expect(compose).toContain("${MOIRA_IMAGE:-ghcr.io/moira-mcp/moira:latest}");
+    expect(readme).toContain("data/.moira-startup-backups/");
+    expect(english).toContain("persistent initialization-pending marker");
+    expect(english).toContain("without a fake database backup");
+    expect(russian).toContain("persistent-маркер незавершённой инициализации");
+    expect(russian).toContain("без фиктивной backup-БД");
+    for (const source of [english, russian, envExample, compose, readme]) {
+      expect(source).not.toContain("ghcr.io/moira-mcp/moira:0.3.5");
+      expect(source).not.toContain("ghcr.io/moira-mcp/moira:0.3.6");
+    }
   });
 });

--- a/tests/unit/scripts/self-host-startup-guard.test.ts
+++ b/tests/unit/scripts/self-host-startup-guard.test.ts
@@ -1,0 +1,647 @@
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, test } from "@jest/globals";
+
+const guard = path.resolve("scripts/self-host-startup-guard.sh");
+const entrypoint = path.resolve("scripts/container-entrypoint.sh");
+
+function sqlite(db: string, statement: string): string {
+  return execFileSync("sqlite3", [db, statement], { encoding: "utf8" }).trim();
+}
+
+function writeCommand(dir: string, body: string): string {
+  const command = path.join(dir, "init.sh");
+  fs.writeFileSync(command, `#!/bin/sh\nset -eu\n${body}\n`, { mode: 0o755 });
+  return command;
+}
+
+function guardEnv(dir: string, db: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    DEPLOYMENT_MODE: "self-host",
+    DB_PATH: db,
+    MOIRA_INIT_SENTINEL_DIR: dir,
+  };
+}
+
+async function waitForFile(file: string, child?: ChildProcess): Promise<void> {
+  const deadline = Date.now() + 5000;
+  while (!fs.existsSync(file)) {
+    if (child?.exitCode !== null) {
+      throw new Error(`process exited before creating ${file}: ${child?.exitCode}`);
+    }
+    if (Date.now() >= deadline) throw new Error(`timed out waiting for ${file}`);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+async function waitForExit(child: ChildProcess): Promise<number | null> {
+  if (child.exitCode !== null) return child.exitCode;
+  return await new Promise((resolve, reject) => {
+    child.once("exit", resolve);
+    child.once("error", reject);
+  });
+}
+
+describe("self-host startup guard", () => {
+  test("entrypoint clears stale sentinels before executing Supervisor's command", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "moira-entrypoint-generation-"));
+    try {
+      fs.writeFileSync(path.join(dir, "init-success"), "stale");
+      fs.writeFileSync(path.join(dir, "init-failed"), "stale");
+      const observed = path.join(dir, "observed");
+      const command = writeCommand(
+        dir,
+        `test ! -e "${dir}/init-success"\ntest ! -e "${dir}/init-failed"\ntouch "${observed}"`,
+      );
+
+      execFileSync(entrypoint, [command], {
+        env: { ...process.env, MOIRA_INIT_SENTINEL_DIR: dir },
+      });
+
+      expect(fs.existsSync(observed)).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("backs up existing state before allowing initialization to commit", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "moira-startup-success-"));
+    const db = path.join(dir, "moira.db");
+    const manifest = path.join(dir, "prompt-manifest.json");
+    try {
+      sqlite(
+        db,
+        "PRAGMA journal_mode=WAL; CREATE TABLE marker(value TEXT); INSERT INTO marker VALUES('before');",
+      );
+      fs.writeFileSync(manifest, '{"state":"before"}\n');
+      const beforeDump = sqlite(db, ".dump");
+      const command = writeCommand(
+        dir,
+        `sqlite3 "$DB_PATH" "UPDATE marker SET value='after';"\nprintf '%s\\n' '{"state":"after"}' > "$(dirname "$DB_PATH")/prompt-manifest.json"`,
+      );
+
+      execFileSync(guard, [command], { env: guardEnv(dir, db) });
+
+      expect(sqlite(db, "SELECT value FROM marker;")).toBe("after");
+      const backupDir = path.join(dir, ".moira-startup-backups", "current");
+      const backup = path.join(backupDir, "moira.db");
+      expect(sqlite(backup, ".dump")).toBe(beforeDump);
+      expect(sqlite(backup, "PRAGMA integrity_check;")).toBe("ok");
+      expect(fs.readFileSync(path.join(backupDir, "prompt-manifest.json"), "utf8")).toBe(
+        '{"state":"before"}\n',
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("restores database and prompt manifest after partial initialization failure", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "moira-startup-failure-"));
+    const db = path.join(dir, "moira.db");
+    const manifest = path.join(dir, "prompt-manifest.json");
+    try {
+      sqlite(
+        db,
+        "PRAGMA journal_mode=WAL; CREATE TABLE marker(value TEXT); INSERT INTO marker VALUES('before');",
+      );
+      fs.writeFileSync(manifest, '{"state":"before"}\n');
+      const beforeDump = sqlite(db, ".dump");
+      const command = writeCommand(
+        dir,
+        `sqlite3 "$DB_PATH" "UPDATE marker SET value='partial'; CREATE TABLE partial(id INTEGER);"\nprintf '%s\\n' '{"state":"partial"}' > "$(dirname "$DB_PATH")/prompt-manifest.json"\nexit 23`,
+      );
+
+      expect(() => execFileSync(guard, [command], { env: guardEnv(dir, db) })).toThrow();
+
+      expect(sqlite(db, ".dump")).toBe(beforeDump);
+      expect(sqlite(db, "SELECT value FROM marker;")).toBe("before");
+      expect(sqlite(db, "SELECT count(*) FROM sqlite_master WHERE name='partial';")).toBe("0");
+      expect(sqlite(db, "PRAGMA integrity_check;")).toBe("ok");
+      expect(fs.readFileSync(manifest, "utf8")).toBe('{"state":"before"}\n');
+      expect(fs.existsSync(path.join(dir, "init-failed"))).toBe(true);
+      expect(
+        sqlite(
+          path.join(dir, ".moira-startup-backups", "current", "moira.db"),
+          "PRAGMA integrity_check;",
+        ),
+      ).toBe("ok");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("removes incomplete database state when the first initialization fails", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "moira-startup-first-failure-"));
+    const db = path.join(dir, "moira.db");
+    try {
+      const command = writeCommand(
+        dir,
+        `sqlite3 "$DB_PATH" "CREATE TABLE partial(id INTEGER);"\nprintf '%s\\n' '{}' > "$(dirname "$DB_PATH")/prompt-manifest.json"\nexit 17`,
+      );
+
+      expect(() => execFileSync(guard, [command], { env: guardEnv(dir, db) })).toThrow();
+
+      expect(fs.existsSync(db)).toBe(false);
+      expect(fs.existsSync(`${db}-wal`)).toBe(false);
+      expect(fs.existsSync(`${db}-shm`)).toBe(false);
+      expect(fs.existsSync(path.join(dir, "prompt-manifest.json"))).toBe(false);
+      expect(fs.existsSync(path.join(dir, ".moira-startup-backups"))).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("retains exactly the three most recent pre-startup states", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "moira-startup-rotation-"));
+    const db = path.join(dir, "moira.db");
+    try {
+      sqlite(db, "CREATE TABLE marker(value INTEGER); INSERT INTO marker VALUES(0);");
+      const command = writeCommand(dir, `sqlite3 "$DB_PATH" "UPDATE marker SET value=value+1;"`);
+
+      for (let run = 0; run < 4; run += 1) {
+        execFileSync(guard, [command], { env: guardEnv(dir, db) });
+        if (run === 0) {
+          const current = path.join(dir, ".moira-startup-backups", "current", "moira.db");
+          fs.writeFileSync(`${current}-wal`, "");
+          fs.writeFileSync(`${current}-shm`, "");
+        }
+      }
+
+      const stateDir = path.join(dir, ".moira-startup-backups");
+      expect(sqlite(path.join(stateDir, "current", "moira.db"), "SELECT value FROM marker;")).toBe(
+        "3",
+      );
+      expect(
+        sqlite(path.join(stateDir, "previous-1", "moira.db"), "SELECT value FROM marker;"),
+      ).toBe("2");
+      expect(
+        sqlite(path.join(stateDir, "previous-2", "moira.db"), "SELECT value FROM marker;"),
+      ).toBe("1");
+      expect(fs.readdirSync(stateDir).sort()).toEqual(["current", "previous-1", "previous-2"]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("recovers an interrupted initialization before protecting the next attempt", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "moira-startup-interrupted-"));
+    const db = path.join(dir, "moira.db");
+    const manifest = path.join(dir, "prompt-manifest.json");
+    try {
+      sqlite(db, "CREATE TABLE marker(value TEXT); INSERT INTO marker VALUES('before');");
+      fs.writeFileSync(manifest, '{"state":"before"}\n');
+      const noChange = writeCommand(dir, ":");
+      execFileSync(guard, [noChange], { env: guardEnv(dir, db) });
+
+      sqlite(db, "UPDATE marker SET value='partial'; CREATE TABLE crash_partial(id INTEGER);");
+      fs.writeFileSync(manifest, '{"state":"partial"}\n');
+      const current = path.join(dir, ".moira-startup-backups", "current");
+      fs.writeFileSync(path.join(current, "initialization.pending"), "");
+      const commit = writeCommand(
+        dir,
+        `sqlite3 "$DB_PATH" "UPDATE marker SET value='committed';"\nprintf '%s\\n' '{"state":"committed"}' > "$(dirname "$DB_PATH")/prompt-manifest.json"`,
+      );
+
+      execFileSync(guard, [commit], { env: guardEnv(dir, db) });
+
+      expect(sqlite(db, "SELECT value FROM marker;")).toBe("committed");
+      expect(sqlite(db, "SELECT count(*) FROM sqlite_master WHERE name='crash_partial';")).toBe(
+        "0",
+      );
+      expect(sqlite(path.join(current, "moira.db"), "SELECT value FROM marker;")).toBe("before");
+      expect(fs.readFileSync(path.join(current, "prompt-manifest.json"), "utf8")).toBe(
+        '{"state":"before"}\n',
+      );
+      expect(fs.existsSync(path.join(current, "initialization.pending"))).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("removes an interrupted first start before retrying from empty state", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "moira-startup-interrupted-first-"));
+    const db = path.join(dir, "moira.db");
+    try {
+      sqlite(db, "CREATE TABLE partial(id INTEGER);");
+      fs.writeFileSync(path.join(dir, "prompt-manifest.json"), '{"state":"partial"}\n');
+      const firstStart = path.join(dir, ".moira-startup-backups", "first-start");
+      fs.mkdirSync(firstStart, { recursive: true });
+      fs.writeFileSync(path.join(firstStart, "first-start.pending"), "");
+      fs.writeFileSync(path.join(firstStart, "prompt-manifest.absent"), "");
+      const command = writeCommand(
+        dir,
+        `sqlite3 "$DB_PATH" "CREATE TABLE marker(value TEXT); INSERT INTO marker VALUES('clean');"`,
+      );
+
+      execFileSync(guard, [command], { env: guardEnv(dir, db) });
+
+      expect(sqlite(db, "SELECT value FROM marker;")).toBe("clean");
+      expect(sqlite(db, "SELECT count(*) FROM sqlite_master WHERE name='partial';")).toBe("0");
+      expect(fs.existsSync(path.join(dir, "prompt-manifest.json"))).toBe(false);
+      expect(fs.existsSync(firstStart)).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("clears a stale success sentinel before backup and initialization", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "moira-startup-stale-sentinel-"));
+    const db = path.join(dir, "moira.db");
+    const ready = path.join(dir, "ready");
+    const release = path.join(dir, "release");
+    try {
+      sqlite(db, "CREATE TABLE marker(value TEXT); INSERT INTO marker VALUES('before');");
+      fs.writeFileSync(path.join(dir, "init-success"), "stale");
+      const command = writeCommand(
+        dir,
+        `touch "${ready}"\nwhile [ ! -f "${release}" ]; do sleep 0.05; done`,
+      );
+      const child = spawn(guard, [command], { env: guardEnv(dir, db), stdio: "ignore" });
+
+      await waitForFile(ready, child);
+      expect(fs.existsSync(path.join(dir, "init-success"))).toBe(false);
+      expect(fs.existsSync(path.join(dir, "init-failed"))).toBe(false);
+      fs.writeFileSync(release, "");
+      expect(await waitForExit(child)).toBe(0);
+      expect(fs.existsSync(path.join(dir, "init-success"))).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("publishes failure only after a blocked restore becomes observable", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "moira-startup-failure-order-"));
+    const db = path.join(dir, "moira.db");
+    const manifest = path.join(dir, "prompt-manifest.json");
+    const blocked = path.join(dir, "restore-blocked");
+    const release = path.join(dir, "restore-release");
+    const bin = path.join(dir, "bin");
+    fs.mkdirSync(bin);
+    try {
+      sqlite(db, "CREATE TABLE marker(value TEXT); INSERT INTO marker VALUES('before');");
+      fs.writeFileSync(manifest, '{"state":"before"}\n');
+      const realCp = execFileSync("sh", ["-c", "command -v cp"], { encoding: "utf8" }).trim();
+      fs.writeFileSync(
+        path.join(bin, "cp"),
+        `#!/bin/sh\ncase "$1" in */.moira-startup-backups/current/moira.db) touch "$RESTORE_BLOCKED"; while [ ! -f "$RESTORE_RELEASE" ]; do sleep 0.05; done ;; esac\nexec "${realCp}" "$@"\n`,
+        { mode: 0o755 },
+      );
+      const command = writeCommand(
+        dir,
+        `sqlite3 "$DB_PATH" "UPDATE marker SET value='partial';"\nprintf '%s\\n' '{"state":"partial"}' > "$(dirname "$DB_PATH")/prompt-manifest.json"\nexit 29`,
+      );
+      const child = spawn(guard, [command], {
+        env: {
+          ...guardEnv(dir, db),
+          PATH: `${bin}:${process.env.PATH ?? ""}`,
+          RESTORE_BLOCKED: blocked,
+          RESTORE_RELEASE: release,
+        },
+        stdio: "ignore",
+      });
+
+      await waitForFile(blocked, child);
+      expect(fs.existsSync(path.join(dir, "init-failed"))).toBe(false);
+      expect(sqlite(db, "SELECT value FROM marker;")).toBe("partial");
+      fs.writeFileSync(release, "");
+      expect(await waitForExit(child)).toBe(29);
+      expect(sqlite(db, "SELECT value FROM marker;")).toBe("before");
+      expect(fs.readFileSync(manifest, "utf8")).toBe('{"state":"before"}\n');
+      expect(fs.existsSync(path.join(dir, "init-failed"))).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps first-start recovery when incomplete data cannot be removed", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "moira-startup-remove-fault-"));
+    const sentinels = fs.mkdtempSync(path.join(os.tmpdir(), "moira-startup-remove-sentinel-"));
+    const db = path.join(dir, "moira.db");
+    try {
+      const command = writeCommand(
+        dir,
+        `sqlite3 "$DB_PATH" "CREATE TABLE partial(id INTEGER);"\nchmod 500 "$(dirname "$DB_PATH")"\nexit 31`,
+      );
+      expect(() =>
+        execFileSync(guard, [command], {
+          env: { ...guardEnv(sentinels, db), MOIRA_INIT_SENTINEL_DIR: sentinels },
+        }),
+      ).toThrow();
+
+      fs.chmodSync(dir, 0o700);
+      expect(fs.existsSync(db)).toBe(true);
+      expect(
+        fs.existsSync(
+          path.join(dir, ".moira-startup-backups", "first-start", "first-start.pending"),
+        ),
+      ).toBe(true);
+      expect(fs.existsSync(path.join(sentinels, "init-failed"))).toBe(true);
+      const retry = writeCommand(
+        dir,
+        `sqlite3 "$DB_PATH" "CREATE TABLE marker(value TEXT); INSERT INTO marker VALUES('clean');"`,
+      );
+      execFileSync(guard, [retry], {
+        env: { ...guardEnv(sentinels, db), MOIRA_INIT_SENTINEL_DIR: sentinels },
+      });
+      expect(sqlite(db, "SELECT value FROM marker;")).toBe("clean");
+      expect(sqlite(db, "SELECT count(*) FROM sqlite_master WHERE name='partial';")).toBe("0");
+    } finally {
+      fs.chmodSync(dir, 0o700);
+      fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(sentinels, { recursive: true, force: true });
+    }
+  });
+
+  test("never publishes success when the pending marker cannot commit", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "moira-startup-marker-fault-"));
+    const db = path.join(dir, "moira.db");
+    const current = path.join(dir, ".moira-startup-backups", "current");
+    try {
+      sqlite(db, "CREATE TABLE marker(value TEXT); INSERT INTO marker VALUES('before');");
+      const command = writeCommand(dir, `chmod 500 "${current}"`);
+      expect(() => execFileSync(guard, [command], { env: guardEnv(dir, db) })).toThrow();
+
+      fs.chmodSync(current, 0o700);
+      expect(sqlite(db, "SELECT value FROM marker;")).toBe("before");
+      expect(fs.existsSync(path.join(current, "initialization.pending"))).toBe(true);
+      expect(fs.existsSync(path.join(dir, "init-success"))).toBe(false);
+      expect(fs.existsSync(path.join(dir, "init-failed"))).toBe(true);
+      const retry = writeCommand(dir, `sqlite3 "$DB_PATH" "UPDATE marker SET value='after';"`);
+      execFileSync(guard, [retry], { env: guardEnv(dir, db) });
+      expect(sqlite(db, "SELECT value FROM marker;")).toBe("after");
+    } finally {
+      if (fs.existsSync(current)) fs.chmodSync(current, 0o700);
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("restores data when the success sentinel cannot be published", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "moira-startup-sentinel-fault-"));
+    const sentinels = fs.mkdtempSync(path.join(os.tmpdir(), "moira-startup-sentinel-dir-"));
+    const db = path.join(dir, "moira.db");
+    try {
+      sqlite(db, "CREATE TABLE marker(value TEXT); INSERT INTO marker VALUES('before');");
+      fs.chmodSync(sentinels, 0o500);
+      const command = writeCommand(dir, `sqlite3 "$DB_PATH" "UPDATE marker SET value='partial';"`);
+      expect(() =>
+        execFileSync(guard, [command], {
+          env: { ...guardEnv(sentinels, db), MOIRA_INIT_SENTINEL_DIR: sentinels },
+        }),
+      ).toThrow();
+
+      expect(sqlite(db, "SELECT value FROM marker;")).toBe("before");
+      expect(fs.existsSync(path.join(sentinels, "init-success"))).toBe(false);
+      fs.chmodSync(sentinels, 0o700);
+      const retry = writeCommand(dir, `sqlite3 "$DB_PATH" "UPDATE marker SET value='after';"`);
+      execFileSync(guard, [retry], {
+        env: { ...guardEnv(sentinels, db), MOIRA_INIT_SENTINEL_DIR: sentinels },
+      });
+      expect(sqlite(db, "SELECT value FROM marker;")).toBe("after");
+    } finally {
+      fs.chmodSync(sentinels, 0o700);
+      fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(sentinels, { recursive: true, force: true });
+    }
+  });
+
+  test("retains recovery state when prompt-manifest restore is faulted", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "moira-startup-manifest-fault-"));
+    const db = path.join(dir, "moira.db");
+    const manifest = path.join(dir, "prompt-manifest.json");
+    const bin = path.join(dir, "bin");
+    fs.mkdirSync(bin);
+    try {
+      sqlite(db, "CREATE TABLE marker(value TEXT); INSERT INTO marker VALUES('before');");
+      fs.writeFileSync(manifest, '{"state":"before"}\n');
+      const realCp = execFileSync("sh", ["-c", "command -v cp"], { encoding: "utf8" }).trim();
+      fs.writeFileSync(
+        path.join(bin, "cp"),
+        `#!/bin/sh\ncase "$2" in */.moira-manifest-restore.*) exit 47 ;; esac\nexec "${realCp}" "$@"\n`,
+        { mode: 0o755 },
+      );
+      const command = writeCommand(
+        dir,
+        `sqlite3 "$DB_PATH" "UPDATE marker SET value='partial';"\nprintf '%s\\n' '{"state":"partial"}' > "$(dirname "$DB_PATH")/prompt-manifest.json"\nexit 41`,
+      );
+      expect(() =>
+        execFileSync(guard, [command], {
+          env: { ...guardEnv(dir, db), PATH: `${bin}:${process.env.PATH ?? ""}` },
+        }),
+      ).toThrow();
+
+      const current = path.join(dir, ".moira-startup-backups", "current");
+      expect(fs.existsSync(path.join(current, "initialization.pending"))).toBe(true);
+      expect(fs.existsSync(path.join(dir, "init-success"))).toBe(false);
+      expect(fs.existsSync(path.join(dir, "init-failed"))).toBe(true);
+      const retry = writeCommand(dir, ":");
+      execFileSync(guard, [retry], { env: guardEnv(dir, db) });
+      expect(sqlite(db, "SELECT value FROM marker;")).toBe("before");
+      expect(fs.readFileSync(manifest, "utf8")).toBe('{"state":"before"}\n');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("fails closed for stale staging symlinks without writing outside state", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "moira-startup-staging-symlink-"));
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), "moira-startup-staging-outside-"));
+    const db = path.join(dir, "moira.db");
+    try {
+      sqlite(db, "CREATE TABLE marker(value TEXT); INSERT INTO marker VALUES('before');");
+      const stateDir = path.join(dir, ".moira-startup-backups");
+      fs.mkdirSync(stateDir);
+      fs.symlinkSync(outside, path.join(stateDir, ".next.attack"));
+      const command = writeCommand(dir, `sqlite3 "$DB_PATH" "UPDATE marker SET value='after';"`);
+
+      expect(() => execFileSync(guard, [command], { env: guardEnv(dir, db) })).toThrow();
+
+      expect(sqlite(db, "SELECT value FROM marker;")).toBe("before");
+      expect(fs.readdirSync(outside)).toEqual([]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects stale database-restore symlinks before interrupted-state recovery", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "moira-startup-db-restore-symlink-"));
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), "moira-startup-db-restore-outside-"));
+    const db = path.join(dir, "moira.db");
+    const target = path.join(outside, "target");
+    const suspicious = path.join(dir, ".moira-db-restore.attack");
+    try {
+      sqlite(db, "CREATE TABLE marker(value TEXT); INSERT INTO marker VALUES('before');");
+      const noChange = writeCommand(dir, ":");
+      execFileSync(guard, [noChange], { env: guardEnv(dir, db) });
+      sqlite(db, "UPDATE marker SET value='partial';");
+      const current = path.join(dir, ".moira-startup-backups", "current");
+      fs.writeFileSync(path.join(current, "initialization.pending"), "");
+      fs.writeFileSync(target, "outside");
+      fs.symlinkSync(target, suspicious);
+
+      expect(() => execFileSync(guard, [noChange], { env: guardEnv(dir, db) })).toThrow();
+
+      expect(fs.readFileSync(target, "utf8")).toBe("outside");
+      expect(sqlite(db, "SELECT value FROM marker;")).toBe("partial");
+      fs.unlinkSync(suspicious);
+      execFileSync(guard, [noChange], { env: guardEnv(dir, db) });
+      expect(sqlite(db, "SELECT value FROM marker;")).toBe("before");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects stale manifest-restore symlinks before interrupted first-start recovery", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "moira-startup-manifest-symlink-"));
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), "moira-startup-manifest-outside-"));
+    const db = path.join(dir, "moira.db");
+    const target = path.join(outside, "target");
+    const suspicious = path.join(dir, ".moira-manifest-restore.attack");
+    try {
+      sqlite(db, "CREATE TABLE partial(id INTEGER);");
+      const firstStart = path.join(dir, ".moira-startup-backups", "first-start");
+      fs.mkdirSync(firstStart, { recursive: true });
+      fs.writeFileSync(path.join(firstStart, "first-start.pending"), "");
+      fs.writeFileSync(path.join(firstStart, "prompt-manifest.json"), '{"state":"before"}\n');
+      fs.writeFileSync(target, "outside");
+      fs.symlinkSync(target, suspicious);
+      const command = writeCommand(
+        dir,
+        `sqlite3 "$DB_PATH" "CREATE TABLE marker(value TEXT); INSERT INTO marker VALUES('clean');"`,
+      );
+
+      expect(() => execFileSync(guard, [command], { env: guardEnv(dir, db) })).toThrow();
+
+      expect(fs.readFileSync(target, "utf8")).toBe("outside");
+      expect(sqlite(db, "SELECT count(*) FROM sqlite_master WHERE name='partial';")).toBe("1");
+      fs.unlinkSync(suspicious);
+      execFileSync(guard, [command], { env: guardEnv(dir, db) });
+      expect(sqlite(db, "SELECT count(*) FROM sqlite_master WHERE name='partial';")).toBe("0");
+      expect(sqlite(db, "SELECT value FROM marker;")).toBe("clean");
+      expect(fs.readFileSync(path.join(dir, "prompt-manifest.json"), "utf8")).toBe(
+        '{"state":"before"}\n',
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  test("removes stale real staging directories before creating a fresh backup", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "moira-startup-stale-staging-"));
+    const db = path.join(dir, "moira.db");
+    try {
+      sqlite(db, "CREATE TABLE marker(value TEXT); INSERT INTO marker VALUES('before');");
+      const stale = path.join(dir, ".moira-startup-backups", ".next.dead");
+      fs.mkdirSync(stale, { recursive: true });
+      fs.writeFileSync(path.join(stale, "moira.db.tmp.42"), "partial");
+      const command = writeCommand(dir, `sqlite3 "$DB_PATH" "UPDATE marker SET value='after';"`);
+
+      execFileSync(guard, [command], { env: guardEnv(dir, db) });
+
+      expect(fs.existsSync(stale)).toBe(false);
+      expect(sqlite(db, "SELECT value FROM marker;")).toBe("after");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("cleans SIGKILL staging left during backup before retry", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "moira-startup-backup-kill-"));
+    const db = path.join(dir, "moira.db");
+    const blocked = path.join(dir, "backup-blocked");
+    const bin = path.join(dir, "bin");
+    fs.mkdirSync(bin);
+    try {
+      sqlite(db, "CREATE TABLE marker(value TEXT); INSERT INTO marker VALUES('before');");
+      const realSqlite = execFileSync("sh", ["-c", "command -v sqlite3"], {
+        encoding: "utf8",
+      }).trim();
+      fs.writeFileSync(
+        path.join(bin, "sqlite3"),
+        `#!/bin/sh\ncase "$*" in *".backup "*) touch "$BACKUP_BLOCKED"; while :; do sleep 1; done ;; esac\nexec "${realSqlite}" "$@"\n`,
+        { mode: 0o755 },
+      );
+      const command = writeCommand(dir, ":");
+      const child = spawn(guard, [command], {
+        detached: true,
+        env: {
+          ...guardEnv(dir, db),
+          PATH: `${bin}:${process.env.PATH ?? ""}`,
+          BACKUP_BLOCKED: blocked,
+        },
+        stdio: "ignore",
+      });
+      await waitForFile(blocked, child);
+
+      process.kill(-(child.pid as number), "SIGKILL");
+      await waitForExit(child);
+      const stateDir = path.join(dir, ".moira-startup-backups");
+      expect(fs.readdirSync(stateDir).some((name) => name.startsWith(".next."))).toBe(true);
+      execFileSync(guard, [command], { env: guardEnv(dir, db) });
+      expect(fs.readdirSync(stateDir).some((name) => name.startsWith(".next."))).toBe(false);
+      expect(sqlite(db, "SELECT value FROM marker;")).toBe("before");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("restores state and publishes failure when terminated during mutation", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "moira-startup-sigterm-"));
+    const db = path.join(dir, "moira.db");
+    const ready = path.join(dir, "ready");
+    try {
+      sqlite(db, "CREATE TABLE marker(value TEXT); INSERT INTO marker VALUES('before');");
+      const command = writeCommand(
+        dir,
+        `sqlite3 "$DB_PATH" "UPDATE marker SET value='partial';"\ntouch "${ready}"\ntrap 'exit 143' TERM INT HUP\nwhile :; do sleep 1; done`,
+      );
+      const child = spawn(guard, [command], { env: guardEnv(dir, db), stdio: "ignore" });
+      await waitForFile(ready, child);
+
+      child.kill("SIGTERM");
+      expect(await waitForExit(child)).not.toBe(0);
+      expect(sqlite(db, "SELECT value FROM marker;")).toBe("before");
+      expect(fs.existsSync(path.join(dir, "init-failed"))).toBe(true);
+      expect(fs.existsSync(path.join(dir, "init-success"))).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("recovers on retry after process-group SIGKILL during mutation", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "moira-startup-sigkill-"));
+    const db = path.join(dir, "moira.db");
+    const ready = path.join(dir, "ready");
+    try {
+      sqlite(db, "CREATE TABLE marker(value TEXT); INSERT INTO marker VALUES('before');");
+      const command = writeCommand(
+        dir,
+        `sqlite3 "$DB_PATH" "UPDATE marker SET value='partial'; CREATE TABLE crash_partial(id INTEGER);"\ntouch "${ready}"\nwhile :; do sleep 1; done`,
+      );
+      const child = spawn(guard, [command], {
+        detached: true,
+        env: guardEnv(dir, db),
+        stdio: "ignore",
+      });
+      await waitForFile(ready, child);
+
+      process.kill(-(child.pid as number), "SIGKILL");
+      await waitForExit(child);
+      expect(sqlite(db, "SELECT value FROM marker;")).toBe("partial");
+      const retry = writeCommand(dir, `sqlite3 "$DB_PATH" "UPDATE marker SET value='after';"`);
+      execFileSync(guard, [retry], { env: guardEnv(dir, db) });
+      expect(sqlite(db, "SELECT value FROM marker;")).toBe("after");
+      expect(sqlite(db, "SELECT count(*) FROM sqlite_master WHERE name='crash_partial';")).toBe(
+        "0",
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/scripts/self-host-upgrade-contract.test.ts
+++ b/tests/unit/scripts/self-host-upgrade-contract.test.ts
@@ -5,12 +5,34 @@ import { describe, expect, test } from "@jest/globals";
 
 describe("self-host upgrade contract", () => {
   const script = readFileSync(resolve("scripts/self-host-upgrade.sh"), "utf8");
+  const startupGuard = readFileSync(resolve("scripts/self-host-startup-guard.sh"), "utf8");
   const compose = readFileSync(resolve("docker-compose.yml"), "utf8");
+  const supervisor = readFileSync(resolve("config/supervisord.conf"), "utf8");
+  const entrypoint = readFileSync(resolve("scripts/container-entrypoint.sh"), "utf8");
   const gitignore = readFileSync(resolve(".gitignore"), "utf8");
   const dockerignore = readFileSync(resolve(".dockerignore"), "utf8");
 
-  test("requires immutable pins and delegates coherent backup", () => {
-    expect(compose).toContain("${MOIRA_IMAGE:-ghcr.io/moira-mcp/moira:0.3.5}");
+  test("uses latest for quickstart and guards self-host initialization inside the image", () => {
+    expect(compose).toContain("${MOIRA_IMAGE:-ghcr.io/moira-mcp/moira:latest}");
+    expect(supervisor).toContain(
+      "command=/app/scripts/self-host-startup-guard.sh /app/scripts/init-database.sh",
+    );
+    expect(supervisor).toContain("stopasgroup=true");
+    expect(supervisor).toContain("killasgroup=true");
+    expect(entrypoint).toContain(
+      'rm -f -- "$sentinel_dir/init-success" "$sentinel_dir/init-failed"',
+    );
+    expect(startupGuard).toContain("sqlite-online-backup.sh");
+    expect(startupGuard).toContain(".moira-startup-backups");
+    expect(startupGuard).toContain("initialization.pending");
+    expect(startupGuard).toContain("initialization.committed");
+    expect(startupGuard).toContain("MOIRA_INIT_SENTINEL_OWNER=guard");
+    expect(startupGuard).toContain('mktemp -d "$STATE_DIR/.next.XXXXXX"');
+    expect(startupGuard).toContain("STARTUP_RESTORE_OK");
+    expect(startupGuard).not.toContain("docker ");
+  });
+
+  test("keeps the advanced helper pinned and delegates coherent backup", () => {
     expect(script).toContain("mutable image tags are forbidden");
     expect(script).toContain("/app/scripts/sqlite-online-backup.sh");
     expect(script).toContain(":/source:ro");


### PR DESCRIPTION
Summary:
- make the public Compose quickstart use the published latest image
- protect existing SQLite and prompt-manifest state automatically inside image startup
- recover ordinary failures, interrupted starts, same-container restarts, and first-start failures before services are admitted
- keep the repository upgrade helper optional for advanced pinned-image preflight

Verification:
- Node 20 unit suite: 1564 passed
- startup guard focused suite: 20 passed
- documentation parity: 12 passed
- Docker image contract: 3 passed
- real Compose upgrade, failure restore, and same-container blocked-backup restart fixtures reached the expected states
- independent frozen semantic review: zero blockers