### PR TITLE
feat(github): coordinate external issue claims

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Report a problem so we can fix it
 title: ""
-labels: bug
+labels: "type:bug, status:needs-triage"
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea or improvement
 title: ""
-labels: enhancement
+labels: "type:feature, status:needs-triage"
 assignees: ""
 ---
 

--- a/.github/ISSUE_TRIAGE.md
+++ b/.github/ISSUE_TRIAGE.md
@@ -1,0 +1,79 @@
+# Issue triage
+
+Labels describe independent dimensions of an issue. Prefixes make each dimension
+searchable and prevent labels with overlapping meanings.
+
+## Status
+
+Every open issue has exactly one `status:*` label. Replace the previous status when
+the issue moves; do not accumulate lifecycle labels.
+
+| Label                        | Meaning                                                                                             |
+| ---------------------------- | --------------------------------------------------------------------------------------------------- |
+| `status:needs-triage`        | A maintainer has not yet decided whether the issue is actionable.                                   |
+| `status:waiting-for-author`  | A maintainer requested information, reproduction details, or a concrete use case from the reporter. |
+| `status:needs-design`        | The problem is understood, but product, API, security, or architecture design is not accepted yet.  |
+| `status:needs-investigation` | The issue is actionable enough to investigate, but its cause or solution is not established.        |
+| `status:ready`               | Scope and acceptance are sufficient and the unassigned issue can be claimed.                        |
+| `status:in-progress`         | Work is underway; ownership requires one assignee, not this label alone.                            |
+| `status:blocked`             | Accepted work is waiting for a named dependency or decision. State that dependency in the issue.    |
+
+When the reporter supplies requested information, remove
+`status:waiting-for-author` and triage the issue again. Do not use `status:blocked`
+for an untriaged proposal.
+
+## Classification
+
+- Use one `type:*` label: `type:bug`, `type:feature`, `type:chore`, `type:docs`,
+  `type:question`, or `type:epic`.
+- Add every applicable `component:*` label. Use `component:workflow-engine` for
+  runtime orchestration and `component:workflows` for bundled workflow definitions
+  and authoring contracts.
+- Use `type:epic` when the requested outcome must be decomposed into independently
+  deliverable child issues. Child issues use their own concrete type.
+- Maintainers assign at most one `priority:*` label after triage. Absence of
+  priority means it has not been scheduled, not that it is low priority.
+- `good first issue` and `help wanted` describe contribution readiness and do not
+  replace type, component, status, or priority.
+
+## Contribution readiness and ownership
+
+Mark an issue `status:ready` only when its scope and acceptance criteria support
+independent implementation. Epics must be split first. A ready issue intended for
+contributors is unassigned; an assignee means ownership even if a stale label says
+otherwise.
+
+Outside contributors reserve work through the exact `/claim` comment documented
+in [`CONTRIBUTING.md`](../CONTRIBUTING.md). The automation moves a successful claim
+to `status:in-progress`, records one assignee, and maintains a bounded activity
+lease. `/release` and inactive-lease expiry return it to unassigned
+`status:ready`. Do not manually assign a second contributor to a managed claim.
+
+Manual maintainer ownership remains supported. An assigned in-progress issue
+without a trusted bot lease record is left out of automatic expiry. When labels,
+assignees, or bot records disagree, fail closed: preserve current work, coordinate
+with the assignee, and follow the recovery procedure in `CONTRIBUTING.md` instead
+of guessing or removing ownership.
+
+## Closing
+
+Use `resolution:duplicate`, `resolution:invalid`, `resolution:not-planned`, or
+`resolution:cannot-reproduce` when they explain why an issue is closed. A merged
+implementation is represented by the linked pull request and the closed issue; it
+does not need a permanent resolution label.
+
+Do not automatically close an accepted bug or feature merely because maintainers
+have not acted on it. Stale automation should be limited to issues waiting on
+reporter action. Claim-lease expiry releases ownership but does not close the
+issue.
+
+## Triage sequence
+
+1. Confirm the problem and search for duplicates or an existing epic.
+2. Ask for missing evidence or a concrete use case when it changes the API or
+   acceptance criteria.
+3. Set type and components, then choose one current status.
+4. Split an epic before marking implementation work `status:ready`.
+5. Add priority only after the issue is actionable and compared with the existing
+   roadmap.
+6. Leave a ready contributor issue unassigned so `/claim` can establish ownership.

--- a/.github/scripts/issue-claim.cjs
+++ b/.github/scripts/issue-claim.cjs
@@ -1,0 +1,1460 @@
+"use strict";
+
+const CLAIM_COMMAND = "/claim";
+const RELEASE_COMMAND = "/release";
+const READY_STATUS = "status:ready";
+const IN_PROGRESS_STATUS = "status:in-progress";
+const STATUS_PREFIX = "status:";
+const TYPE_PREFIX = "type:";
+const KNOWN_STATUSES = new Set([
+  "status:needs-triage",
+  "status:waiting-for-author",
+  "status:needs-design",
+  "status:needs-investigation",
+  "status:ready",
+  "status:in-progress",
+  "status:blocked",
+]);
+const KNOWN_TYPES = new Set([
+  "type:bug",
+  "type:feature",
+  "type:chore",
+  "type:docs",
+  "type:question",
+  "type:epic",
+]);
+const ALLOWED_TYPES = new Set(["type:bug", "type:feature", "type:chore", "type:docs"]);
+const STATE_MARKER = "moira-issue-claim-state:v1";
+const REMINDER_MARKER = "moira-issue-claim-reminder:v1";
+const PROCESSED_REACTION = "eyes";
+const TRUSTED_BOT_ID = 41898282;
+const TRUSTED_BOT_LOGIN = "github-actions[bot]";
+const ACTIVE_LEASE_DAYS = 7;
+const REMINDER_GRACE_DAYS = 3;
+
+class TransitionError extends Error {
+  constructor(message, code, details = {}) {
+    super(message);
+    this.name = "TransitionError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+function normalizeLabels(labels = []) {
+  return labels
+    .map((label) => (typeof label === "string" ? label : label?.name))
+    .filter((label) => typeof label === "string" && label.length > 0);
+}
+
+function parseCommand(body) {
+  const command = typeof body === "string" ? body.trim() : "";
+  if (command === CLAIM_COMMAND || command === RELEASE_COMMAND) return command;
+  if (/^\/(claim|release)(?:\s|$)/.test(command)) return "invalid";
+  return null;
+}
+
+function issueSnapshot(response) {
+  const issue = response.data;
+  return {
+    number: issue.number,
+    state: issue.state,
+    isPullRequest: Boolean(issue.pull_request),
+    labels: normalizeLabels(issue.labels),
+    assignees: (issue.assignees || []).map((assignee) => assignee.login),
+  };
+}
+
+function statusLabels(snapshot) {
+  return snapshot.labels.filter((label) => label.startsWith(STATUS_PREFIX));
+}
+
+function hasExactAssignees(snapshot, expectedAssignees) {
+  return (
+    !expectedAssignees ||
+    (snapshot.assignees.length === expectedAssignees.length &&
+      snapshot.assignees.every((login, index) => login === expectedAssignees[index]))
+  );
+}
+
+function validateClaimable(snapshot) {
+  if (snapshot.state !== "open") return { ok: false, reason: "The issue is not open." };
+  if (snapshot.isPullRequest) return { ok: false, reason: "Pull requests cannot be claimed." };
+
+  const statuses = snapshot.labels.filter((label) => label.startsWith(STATUS_PREFIX));
+  if (statuses.length !== 1) {
+    return {
+      ok: false,
+      reason: "The issue has an inconsistent status and needs maintainer recovery.",
+    };
+  }
+  if (!KNOWN_STATUSES.has(statuses[0])) {
+    return {
+      ok: false,
+      reason: "The issue has an unknown status and needs maintainer recovery.",
+    };
+  }
+  if (statuses[0] !== READY_STATUS) {
+    return { ok: false, reason: `The issue is not ready for implementation (${statuses[0]}).` };
+  }
+  if (snapshot.assignees.length !== 0) {
+    return { ok: false, reason: `The issue is already assigned to @${snapshot.assignees[0]}.` };
+  }
+
+  const types = snapshot.labels.filter((label) => label.startsWith(TYPE_PREFIX));
+  if (types.length !== 1) {
+    return {
+      ok: false,
+      reason: "The issue has an inconsistent type and needs maintainer recovery.",
+    };
+  }
+  if (!KNOWN_TYPES.has(types[0])) {
+    return {
+      ok: false,
+      reason: "The issue has an unknown type and needs maintainer recovery.",
+    };
+  }
+  if (!ALLOWED_TYPES.has(types[0])) {
+    return {
+      ok: false,
+      reason: `Issues with ${types[0]} are not independently claimable.`,
+    };
+  }
+
+  return { ok: true };
+}
+
+function validateClaimed(snapshot, claimant) {
+  const statuses = statusLabels(snapshot);
+  return (
+    snapshot.state === "open" &&
+    !snapshot.isPullRequest &&
+    snapshot.assignees.length === 1 &&
+    snapshot.assignees[0] === claimant &&
+    statuses.length === 1 &&
+    statuses[0] === IN_PROGRESS_STATUS
+  );
+}
+
+function validateOwnedReady(snapshot, claimant) {
+  const statuses = statusLabels(snapshot);
+  return (
+    snapshot.state === "open" &&
+    snapshot.assignees.length === 1 &&
+    snapshot.assignees[0] === claimant &&
+    statuses.length === 1 &&
+    statuses[0] === READY_STATUS
+  );
+}
+
+function addDays(isoTimestamp, days) {
+  const value = new Date(isoTimestamp);
+  if (Number.isNaN(value.getTime())) {
+    throw new TransitionError(
+      "GitHub supplied an invalid activity timestamp.",
+      "invalid_timestamp",
+    );
+  }
+  value.setUTCDate(value.getUTCDate() + days);
+  return value.toISOString();
+}
+
+function isTrustedBot(comment) {
+  return comment?.user?.id === TRUSTED_BOT_ID && comment?.user?.login === TRUSTED_BOT_LOGIN;
+}
+
+function stateMarker(state) {
+  return `<!-- ${STATE_MARKER} ${JSON.stringify(state)} -->`;
+}
+
+function renderPendingState(state) {
+  return `Claim transition is being verified.\n\n${stateMarker(state)}`;
+}
+
+function renderActiveState(state) {
+  return [
+    `@${state.claimant} is now assigned to this issue.`,
+    "",
+    `Activity deadline: **${state.activityDeadlineAt}**. Add a progress comment here, open a pull request that closes this issue, or comment on that linked pull request before the deadline. Use \`${RELEASE_COMMAND}\` here if you stop working on it.`,
+    "",
+    stateMarker(state),
+  ].join("\n");
+}
+
+function renderReleasedState(state, reason = "released by the assignee") {
+  return [
+    `The claim by @${state.claimant} was ${reason}. This issue is available again when it has \`${READY_STATUS}\` and no assignee.`,
+    "",
+    stateMarker(state),
+  ].join("\n");
+}
+
+function reminderMarker(state) {
+  return `<!-- ${REMINDER_MARKER} ${JSON.stringify({
+    generation: state.generation,
+    lastActivityAt: state.lastActivityAt,
+  })} -->`;
+}
+
+function renderReminder(state, releaseEligibleAt) {
+  return [
+    `@${state.claimant}, this claim has had no qualifying activity since **${state.lastActivityAt}**.`,
+    "",
+    `Add a progress comment, open a pull request that closes this issue, or comment on that linked pull request. Otherwise the claim becomes eligible for release after **${releaseEligibleAt}** and will be released by the next successful scheduled check.`,
+    "",
+    reminderMarker(state),
+  ].join("\n");
+}
+
+function renderRemindedState(state) {
+  const releaseEligibleAt = addDays(state.remindedAt, REMINDER_GRACE_DAYS);
+  return [
+    `@${state.claimant} remains assigned, but the inactivity reminder was sent at **${state.remindedAt}**.`,
+    "",
+    `The claim becomes eligible for release after **${releaseEligibleAt}**. Qualifying activity renews the seven-day activity deadline; \`${RELEASE_COMMAND}\` releases it immediately.`,
+    "",
+    stateMarker(state),
+  ].join("\n");
+}
+
+function renderClearedReminder(cleanup, renewedAt) {
+  return [
+    `The inactivity reminder for @${cleanup.claimant} was cleared by qualifying activity at **${renewedAt}**.`,
+    "",
+    "The current activity deadline is shown in the trusted claim-state comment.",
+    "",
+    reminderMarker(cleanup),
+  ].join("\n");
+}
+
+function parseStateComment(comment) {
+  if (!isTrustedBot(comment) || typeof comment.body !== "string") return null;
+  const escapedMarker = STATE_MARKER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = comment.body.match(new RegExp(`<!--\\s*${escapedMarker}\\s+({[^]*?})\\s*-->`));
+  if (!match) return null;
+
+  let state;
+  try {
+    state = JSON.parse(match[1]);
+  } catch {
+    return { invalid: true, comment };
+  }
+
+  const validStatus = ["pending", "active", "releasing", "released", "aborted"].includes(
+    state.status,
+  );
+  const valid =
+    state.version === 1 &&
+    typeof state.generation === "string" &&
+    state.generation.length > 0 &&
+    typeof state.claimant === "string" &&
+    /^[A-Za-z0-9-]+$/.test(state.claimant) &&
+    validStatus &&
+    typeof state.claimedAt === "string" &&
+    typeof state.lastActivityAt === "string" &&
+    typeof state.activityDeadlineAt === "string" &&
+    !Number.isNaN(Date.parse(state.claimedAt)) &&
+    !Number.isNaN(Date.parse(state.lastActivityAt)) &&
+    !Number.isNaN(Date.parse(state.activityDeadlineAt)) &&
+    (state.lastCompletedCommandId === null || Number.isSafeInteger(state.lastCompletedCommandId)) &&
+    (state.remindedAt === null ||
+      (typeof state.remindedAt === "string" && !Number.isNaN(Date.parse(state.remindedAt)))) &&
+    (state.reminderCleanup === null ||
+      (typeof state.reminderCleanup === "object" &&
+        state.reminderCleanup !== null &&
+        typeof state.reminderCleanup.generation === "string" &&
+        typeof state.reminderCleanup.claimant === "string" &&
+        typeof state.reminderCleanup.lastActivityAt === "string" &&
+        !Number.isNaN(Date.parse(state.reminderCleanup.lastActivityAt))));
+
+  return valid ? { state, comment } : { invalid: true, comment };
+}
+
+async function listStateRecords(github, coordinates) {
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    ...coordinates,
+    per_page: 100,
+  });
+  const markerComments = comments.filter(
+    (comment) => isTrustedBot(comment) && comment.body?.includes(STATE_MARKER),
+  );
+  return markerComments.map(parseStateComment);
+}
+
+async function listReminderRecords(github, coordinates, state) {
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    ...coordinates,
+    per_page: 100,
+  });
+  const expectedMarker = reminderMarker(state);
+  return comments.filter(
+    (comment) => isTrustedBot(comment) && comment.body?.includes(expectedMarker),
+  );
+}
+
+async function clearReminderRecords(github, core, coordinates, cleanup, renewedAt) {
+  const reminders = await listReminderRecords(github, coordinates, cleanup);
+  let complete = true;
+  for (const reminder of reminders) {
+    try {
+      await github.rest.issues.updateComment({
+        ...coordinates,
+        comment_id: reminder.id,
+        body: renderClearedReminder(cleanup, renewedAt),
+      });
+    } catch (error) {
+      complete = false;
+      core.warning(
+        `Lease renewed for #${coordinates.issue_number}, but reminder ${reminder.id} could not be marked cleared: ${error.message}`,
+      );
+    }
+  }
+  return complete;
+}
+
+async function getIssue(github, coordinates) {
+  return issueSnapshot(await github.rest.issues.get(coordinates));
+}
+
+async function removeTransitionLabel(github, coordinates, name) {
+  try {
+    await github.rest.issues.removeLabel({ ...coordinates, name });
+  } catch (error) {
+    const current = await getIssue(github, coordinates);
+    if (current.labels.includes(name)) throw error;
+  }
+}
+
+async function transitionStatus({ github, coordinates, from, to, expectedAssignees }) {
+  let current = await getIssue(github, coordinates);
+  let statuses = statusLabels(current);
+  if (
+    statuses.length === 1 &&
+    statuses[0] === to &&
+    hasExactAssignees(current, expectedAssignees)
+  ) {
+    return current;
+  }
+  if (
+    statuses.length !== 1 ||
+    statuses[0] !== from ||
+    !hasExactAssignees(current, expectedAssignees)
+  ) {
+    throw new TransitionError(
+      `Status transition ${from} → ${to} lost its precondition.`,
+      "status_precondition",
+    );
+  }
+
+  let addError = null;
+  try {
+    await github.rest.issues.addLabels({ ...coordinates, labels: [to] });
+  } catch (error) {
+    addError = error;
+  }
+  current = await getIssue(github, coordinates);
+  statuses = statusLabels(current);
+  if (
+    statuses.length === 1 &&
+    statuses[0] === to &&
+    hasExactAssignees(current, expectedAssignees)
+  ) {
+    return current;
+  }
+  if (
+    statuses.length !== 2 ||
+    !statuses.includes(from) ||
+    !statuses.includes(to) ||
+    !hasExactAssignees(current, expectedAssignees)
+  ) {
+    if (statuses.includes(to) && (statuses.includes(from) || statuses.length > 1)) {
+      await removeTransitionLabel(github, coordinates, to);
+    }
+    throw (
+      addError ||
+      new TransitionError(
+        `Status transition ${from} → ${to} encountered a competing change.`,
+        "status_competing_change",
+      )
+    );
+  }
+
+  let removeError = null;
+  try {
+    await github.rest.issues.removeLabel({ ...coordinates, name: from });
+  } catch (error) {
+    removeError = error;
+  }
+  current = await getIssue(github, coordinates);
+  statuses = statusLabels(current);
+  if (
+    statuses.length === 1 &&
+    statuses[0] === to &&
+    hasExactAssignees(current, expectedAssignees)
+  ) {
+    return current;
+  }
+  if (statuses.includes(to) && (statuses.includes(from) || statuses.length > 1)) {
+    await removeTransitionLabel(github, coordinates, to);
+  }
+  throw (
+    removeError ||
+    new TransitionError(
+      `Status transition ${from} → ${to} did not reach its invariant.`,
+      "status_invariant",
+    )
+  );
+}
+
+async function createRequiredComment(github, coordinates, body) {
+  const response = await github.rest.issues.createComment({ ...coordinates, body });
+  if (!isTrustedBot(response.data)) {
+    throw new TransitionError(
+      "GitHub did not persist the required bot response.",
+      "required_comment_failed",
+    );
+  }
+  return response.data;
+}
+
+async function bestEffortComment(github, coordinates, body) {
+  try {
+    await github.rest.issues.createComment({ ...coordinates, body });
+  } catch {
+    // The workflow failure remains visible even when GitHub also rejects the explanatory comment.
+  }
+}
+
+async function restoreClaimableState({ github, coordinates, claimant }) {
+  const failures = [];
+  let current = await getIssue(github, coordinates);
+
+  // Remove only automation's provisional ownership first. A newer maintainer assignee
+  // makes status restoration unsafe and must be preserved for explicit recovery.
+  if (current.assignees.includes(claimant)) {
+    try {
+      await github.rest.issues.removeAssignees({ ...coordinates, assignees: [claimant] });
+    } catch (error) {
+      failures.push(`assignee: ${error.message}`);
+    }
+  }
+
+  current = await getIssue(github, coordinates);
+  if (
+    current.assignees.length === 0 &&
+    statusLabels(current).length === 1 &&
+    statusLabels(current)[0] === IN_PROGRESS_STATUS
+  ) {
+    try {
+      await transitionStatus({
+        github,
+        coordinates,
+        from: IN_PROGRESS_STATUS,
+        to: READY_STATUS,
+        expectedAssignees: [],
+      });
+    } catch (error) {
+      failures.push(`labels: ${error.message}`);
+    }
+  }
+
+  const finalState = await getIssue(github, coordinates);
+  const finalStatuses = statusLabels(finalState);
+  const restored =
+    finalState.assignees.length === 0 &&
+    finalStatuses.length === 1 &&
+    finalStatuses[0] === READY_STATUS;
+  return { restored, failures, finalState };
+}
+
+async function claimIssue({ github, core, coordinates, claimant, activityAt, triggerCommentId }) {
+  const initial = await getIssue(github, coordinates);
+  const eligibility = validateClaimable(initial);
+  if (!eligibility.ok) {
+    await createRequiredComment(
+      github,
+      coordinates,
+      `@${claimant}, claim rejected: ${eligibility.reason}`,
+    );
+    return { outcome: "rejected", reason: eligibility.reason };
+  }
+
+  const records = await listStateRecords(github, coordinates);
+  if (records.some((record) => !record || record.invalid) || records.length > 1) {
+    const reason = "The trusted claim record is ambiguous and needs maintainer recovery.";
+    await createRequiredComment(github, coordinates, `@${claimant}, claim rejected: ${reason}`);
+    return { outcome: "rejected", reason };
+  }
+  const existingRecord = records[0] || null;
+  if (existingRecord && !["released", "aborted"].includes(existingRecord.state.status)) {
+    const reason =
+      "The issue state and its trusted claim record disagree; a maintainer must recover it.";
+    await createRequiredComment(github, coordinates, `@${claimant}, claim rejected: ${reason}`);
+    return { outcome: "rejected", reason };
+  }
+
+  let stateComment = existingRecord?.comment || null;
+  const previousStateBody = stateComment?.body;
+  let state = {
+    version: 1,
+    generation: `${coordinates.issue_number}-${triggerCommentId}`,
+    claimant,
+    status: "pending",
+    claimedAt: activityAt,
+    lastActivityAt: activityAt,
+    activityDeadlineAt: addDays(activityAt, ACTIVE_LEASE_DAYS),
+    remindedAt: null,
+    reminderCleanup: null,
+    lastCompletedCommandId: triggerCommentId,
+  };
+
+  try {
+    await github.rest.issues.addAssignees({ ...coordinates, assignees: [claimant] });
+    let current = await getIssue(github, coordinates);
+    if (
+      current.assignees.length !== 1 ||
+      current.assignees[0] !== claimant ||
+      validateClaimable({ ...current, assignees: [] }).ok !== true
+    ) {
+      throw new TransitionError(
+        "GitHub did not establish sole ownership.",
+        "assignment_not_applied",
+      );
+    }
+
+    await transitionStatus({
+      github,
+      coordinates,
+      from: READY_STATUS,
+      to: IN_PROGRESS_STATUS,
+      expectedAssignees: [claimant],
+    });
+    current = await getIssue(github, coordinates);
+    if (!validateClaimed(current, claimant)) {
+      throw new TransitionError(
+        "The issue did not reach the claimed invariant.",
+        "claim_invariant",
+      );
+    }
+
+    const pendingBody = renderPendingState(state);
+    const stateResponse = stateComment
+      ? await github.rest.issues.updateComment({
+          ...coordinates,
+          comment_id: stateComment.id,
+          body: pendingBody,
+        })
+      : await github.rest.issues.createComment({ ...coordinates, body: pendingBody });
+    stateComment = stateResponse.data;
+    const parsedPending = parseStateComment(stateComment);
+    if (
+      !parsedPending ||
+      parsedPending.invalid ||
+      parsedPending.state.generation !== state.generation
+    ) {
+      throw new TransitionError(
+        "GitHub did not persist a trusted claim record.",
+        "state_not_applied",
+      );
+    }
+
+    current = await getIssue(github, coordinates);
+    if (!validateClaimed(current, claimant)) {
+      throw new TransitionError("The issue changed before claim confirmation.", "claim_changed");
+    }
+
+    state = { ...state, status: "active" };
+    const confirmation = await github.rest.issues.updateComment({
+      ...coordinates,
+      comment_id: stateComment.id,
+      body: renderActiveState(state),
+    });
+    const parsedActive = parseStateComment(confirmation.data);
+    if (!parsedActive || parsedActive.invalid || parsedActive.state.status !== "active") {
+      throw new TransitionError(
+        "GitHub did not persist claim confirmation.",
+        "confirmation_failed",
+      );
+    }
+
+    return { outcome: "claimed", claimant, state, commentId: confirmation.data.id };
+  } catch (error) {
+    if (stateComment) {
+      const abortedState = { ...state, status: "aborted" };
+      const body =
+        previousStateBody || `Claim transition was aborted.\n\n${stateMarker(abortedState)}`;
+      try {
+        await github.rest.issues.updateComment({
+          ...coordinates,
+          comment_id: stateComment.id,
+          body,
+        });
+      } catch {
+        // The issue transition is compensated below; an ambiguous record fails closed later.
+      }
+    }
+
+    const recovery = await restoreClaimableState({
+      github,
+      coordinates,
+      claimant,
+    });
+    const message = recovery.restored
+      ? `@${claimant}, the claim could not be completed and was rolled back. Please try again later.`
+      : `@${claimant}, the claim transition needs maintainer recovery; no success was recorded.`;
+    await createRequiredComment(github, coordinates, message);
+    if (!recovery.restored) core.setFailed(`Claim recovery incomplete: ${error.message}`);
+    return {
+      outcome: recovery.restored ? "rolled_back" : "recovery_required",
+      error: error.message,
+      recovery,
+    };
+  }
+}
+
+async function releaseIssue({
+  github,
+  core,
+  coordinates,
+  claimant,
+  releaseReason = "released by the assignee",
+  releaseCommandId = null,
+}) {
+  const initial = await getIssue(github, coordinates);
+  const statuses = initial.labels.filter((label) => label.startsWith(STATUS_PREFIX));
+  if (
+    initial.state !== "open" ||
+    initial.isPullRequest ||
+    initial.assignees.length !== 1 ||
+    initial.assignees[0] !== claimant ||
+    statuses.length !== 1 ||
+    statuses[0] !== IN_PROGRESS_STATUS
+  ) {
+    const owner = initial.assignees[0];
+    const reason = owner
+      ? `only the current sole assignee (@${owner}) can release this issue.`
+      : "the issue does not have one active claim to release.";
+    await createRequiredComment(github, coordinates, `@${claimant}, release rejected: ${reason}`);
+    return { outcome: "rejected", reason };
+  }
+
+  const records = await listStateRecords(github, coordinates);
+  if (
+    records.length !== 1 ||
+    !records[0] ||
+    records[0].invalid ||
+    records[0].state.status !== "active" ||
+    records[0].state.claimant !== claimant
+  ) {
+    const reason =
+      "The trusted claim record is missing or inconsistent; a maintainer must recover it.";
+    await createRequiredComment(github, coordinates, `@${claimant}, release rejected: ${reason}`);
+    return { outcome: "rejected", reason };
+  }
+
+  let record = records[0];
+  if (record.state.reminderCleanup) {
+    const cleanup = await finishReminderCleanup({
+      github,
+      core,
+      coordinates,
+      record,
+      state: record.state,
+      renewedAt: record.state.lastActivityAt,
+    });
+    if (!cleanup.complete) {
+      throw new TransitionError(
+        "The visible inactivity reminder could not be cleared before release.",
+        "release_cleanup_pending",
+      );
+    }
+    record = cleanup.record;
+  }
+  const originalBody = record.comment.body;
+  const releasingState = { ...record.state, status: "releasing" };
+
+  try {
+    await github.rest.issues.updateComment({
+      ...coordinates,
+      comment_id: record.comment.id,
+      body: `Release transition is being verified.\n\n${stateMarker(releasingState)}`,
+    });
+    let current = await getIssue(github, coordinates);
+    if (!validateClaimed(current, claimant)) {
+      throw new TransitionError("The issue changed before release mutation.", "release_changed");
+    }
+    await transitionStatus({
+      github,
+      coordinates,
+      from: IN_PROGRESS_STATUS,
+      to: READY_STATUS,
+      expectedAssignees: [claimant],
+    });
+    current = await getIssue(github, coordinates);
+    if (!validateOwnedReady(current, claimant)) {
+      throw new TransitionError(
+        "The issue did not reach the release intermediate state.",
+        "release_labels",
+      );
+    }
+
+    await github.rest.issues.removeAssignees({ ...coordinates, assignees: [claimant] });
+    current = await getIssue(github, coordinates);
+    const currentStatuses = statusLabels(current);
+    if (
+      current.assignees.length !== 0 ||
+      currentStatuses.length !== 1 ||
+      currentStatuses[0] !== READY_STATUS
+    ) {
+      throw new TransitionError(
+        "The issue did not reach the released invariant.",
+        "release_invariant",
+      );
+    }
+
+    const releasedState = {
+      ...record.state,
+      status: "released",
+      lastCompletedCommandId: releaseCommandId ?? record.state.lastCompletedCommandId,
+    };
+    const updated = await github.rest.issues.updateComment({
+      ...coordinates,
+      comment_id: record.comment.id,
+      body: renderReleasedState(releasedState, releaseReason),
+    });
+    const parsed = parseStateComment(updated.data);
+    if (!parsed || parsed.invalid || parsed.state.status !== "released") {
+      throw new TransitionError("The released state record was not persisted.", "release_record");
+    }
+    return { outcome: "released", claimant };
+  } catch (error) {
+    let restored = false;
+    try {
+      let current = await getIssue(github, coordinates);
+      if (
+        current.assignees.length === 0 &&
+        statusLabels(current).length === 1 &&
+        statusLabels(current)[0] === READY_STATUS
+      ) {
+        await github.rest.issues.addAssignees({ ...coordinates, assignees: [claimant] });
+        current = await getIssue(github, coordinates);
+      }
+      if (
+        current.assignees.length === 1 &&
+        current.assignees[0] === claimant &&
+        statusLabels(current).length === 1 &&
+        statusLabels(current)[0] === READY_STATUS
+      ) {
+        await transitionStatus({
+          github,
+          coordinates,
+          from: READY_STATUS,
+          to: IN_PROGRESS_STATUS,
+          expectedAssignees: [claimant],
+        });
+      }
+      await github.rest.issues.updateComment({
+        ...coordinates,
+        comment_id: record.comment.id,
+        body: originalBody,
+      });
+      current = await getIssue(github, coordinates);
+      restored = validateClaimed(current, claimant);
+    } catch {
+      restored = false;
+    }
+
+    const message = restored
+      ? `@${claimant}, release could not be completed; your claim remains active.`
+      : `@${claimant}, release needs maintainer recovery; the issue remains unavailable until reconciled.`;
+    await createRequiredComment(github, coordinates, message);
+    if (!restored) core.setFailed(`Release recovery incomplete: ${error.message}`);
+    return { outcome: restored ? "rolled_back" : "recovery_required", error: error.message };
+  }
+}
+
+async function updateLeaseState(github, coordinates, record, state, body) {
+  const updated = await github.rest.issues.updateComment({
+    ...coordinates,
+    comment_id: record.comment.id,
+    body,
+  });
+  const parsed = parseStateComment(updated.data);
+  if (
+    !parsed ||
+    parsed.invalid ||
+    parsed.state.generation !== state.generation ||
+    parsed.state.status !== state.status ||
+    parsed.state.lastActivityAt !== state.lastActivityAt ||
+    parsed.state.remindedAt !== state.remindedAt ||
+    JSON.stringify(parsed.state.reminderCleanup) !== JSON.stringify(state.reminderCleanup)
+  ) {
+    throw new TransitionError("GitHub did not persist the lease state.", "lease_state_not_applied");
+  }
+  return parsed;
+}
+
+function reminderCleanupFor(state) {
+  if (state.reminderCleanup) return state.reminderCleanup;
+  if (state.remindedAt === null) return null;
+  return {
+    generation: state.generation,
+    claimant: state.claimant,
+    lastActivityAt: state.lastActivityAt,
+  };
+}
+
+async function finishReminderCleanup({ github, core, coordinates, record, state, renewedAt }) {
+  if (!state.reminderCleanup) return { complete: true, record, state };
+  const complete = await clearReminderRecords(
+    github,
+    core,
+    coordinates,
+    state.reminderCleanup,
+    renewedAt,
+  );
+  if (!complete) return { complete: false, record, state };
+  const cleaned = { ...state, reminderCleanup: null };
+  const parsed = await updateLeaseState(
+    github,
+    coordinates,
+    record,
+    cleaned,
+    renderActiveState(cleaned),
+  );
+  return { complete: true, record: parsed, state: cleaned };
+}
+
+async function renewLease({ github, core, coordinates, activityAt, actor }) {
+  const issue = await getIssue(github, coordinates);
+  if (!validateClaimed(issue, actor)) return { outcome: "ignored" };
+
+  const records = await listStateRecords(github, coordinates);
+  if (
+    records.length !== 1 ||
+    !records[0] ||
+    records[0].invalid ||
+    records[0].state.status !== "active" ||
+    records[0].state.claimant !== actor
+  ) {
+    core.warning(`Issue #${coordinates.issue_number} has no unambiguous managed lease to renew.`);
+    return { outcome: "manual_or_recovery" };
+  }
+
+  const record = records[0];
+  if (Date.parse(activityAt) <= Date.parse(record.state.lastActivityAt)) {
+    return { outcome: "unchanged" };
+  }
+
+  const current = await getIssue(github, coordinates);
+  if (!validateClaimed(current, actor)) return { outcome: "manual_override" };
+  const state = {
+    ...record.state,
+    lastActivityAt: activityAt,
+    activityDeadlineAt: addDays(activityAt, ACTIVE_LEASE_DAYS),
+    remindedAt: null,
+    reminderCleanup: reminderCleanupFor(record.state),
+  };
+  const parsed = await updateLeaseState(
+    github,
+    coordinates,
+    record,
+    state,
+    renderActiveState(state),
+  );
+  const cleanup = await finishReminderCleanup({
+    github,
+    core,
+    coordinates,
+    record: parsed,
+    state,
+    renewedAt: activityAt,
+  });
+  return {
+    outcome: cleanup.complete ? "renewed" : "renewed_cleanup_pending",
+    state: cleanup.state,
+  };
+}
+
+async function listCrossReferencedPullRequestNumbers(github, coordinates) {
+  const query = `
+    query CrossReferencedPullRequests(
+      $owner: String!
+      $repo: String!
+      $issueNumber: Int!
+      $cursor: String
+    ) {
+      repository(owner: $owner, name: $repo) {
+        issue(number: $issueNumber) {
+          timelineItems(
+            first: 100
+            after: $cursor
+            itemTypes: [CROSS_REFERENCED_EVENT]
+          ) {
+            nodes {
+              ... on CrossReferencedEvent {
+                source {
+                  ... on PullRequest {
+                    number
+                    repository { nameWithOwner }
+                  }
+                }
+              }
+            }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+      }
+    }
+  `;
+  const numbers = new Set();
+  let cursor = null;
+  do {
+    const result = await github.graphql(query, {
+      owner: coordinates.owner,
+      repo: coordinates.repo,
+      issueNumber: coordinates.issue_number,
+      cursor,
+    });
+    const timeline = result.repository?.issue?.timelineItems;
+    if (!timeline) break;
+    for (const node of timeline.nodes || []) {
+      const source = node?.source;
+      if (
+        source?.repository?.nameWithOwner?.toLowerCase() ===
+        `${coordinates.owner}/${coordinates.repo}`.toLowerCase()
+      ) {
+        numbers.add(source.number);
+      }
+    }
+    cursor = timeline.pageInfo.hasNextPage ? timeline.pageInfo.endCursor : null;
+  } while (cursor);
+  return [...numbers];
+}
+
+async function getClosingPullRequest(github, coordinates, pullNumber) {
+  const query = `
+    query ClosingReferences(
+      $owner: String!
+      $repo: String!
+      $pullNumber: Int!
+      $cursor: String
+    ) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $pullNumber) {
+          number
+          createdAt
+          author { login }
+          closingIssuesReferences(first: 100, after: $cursor) {
+            nodes { number repository { nameWithOwner } }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+      }
+    }
+  `;
+  let cursor = null;
+  let pullRequest = null;
+  let closesIssue = false;
+  do {
+    const result = await github.graphql(query, {
+      owner: coordinates.owner,
+      repo: coordinates.repo,
+      pullNumber,
+      cursor,
+    });
+    const current = result.repository?.pullRequest;
+    if (!current) return null;
+    pullRequest ||= {
+      number: current.number,
+      createdAt: current.createdAt,
+      authorLogin: current.author?.login,
+    };
+    closesIssue ||= (current.closingIssuesReferences.nodes || []).some(
+      (issue) =>
+        issue.number === coordinates.issue_number &&
+        issue.repository?.nameWithOwner?.toLowerCase() ===
+          `${coordinates.owner}/${coordinates.repo}`.toLowerCase(),
+    );
+    cursor = current.closingIssuesReferences.pageInfo.hasNextPage
+      ? current.closingIssuesReferences.pageInfo.endCursor
+      : null;
+  } while (cursor && !closesIssue);
+  return closesIssue ? pullRequest : null;
+}
+
+function laterTimestamp(current, candidate) {
+  if (!candidate || Number.isNaN(Date.parse(candidate))) return current;
+  return Date.parse(candidate) > Date.parse(current) ? candidate : current;
+}
+
+async function findLatestAllowedActivity(github, coordinates, state) {
+  let latest = state.lastActivityAt;
+  const issueComments = await github.paginate(github.rest.issues.listComments, {
+    ...coordinates,
+    per_page: 100,
+  });
+  for (const comment of issueComments) {
+    if (comment.user?.login === state.claimant && comment.body?.trim() !== RELEASE_COMMAND) {
+      latest = laterTimestamp(latest, comment.created_at);
+    }
+  }
+
+  const pullNumbers = await listCrossReferencedPullRequestNumbers(github, coordinates);
+  for (const pullNumber of pullNumbers) {
+    const pullRequest = await getClosingPullRequest(github, coordinates, pullNumber);
+    if (!pullRequest || pullRequest.authorLogin !== state.claimant) continue;
+    latest = laterTimestamp(latest, pullRequest.createdAt);
+
+    const pullComments = await github.paginate(github.rest.issues.listComments, {
+      owner: coordinates.owner,
+      repo: coordinates.repo,
+      issue_number: pullNumber,
+      per_page: 100,
+    });
+    for (const comment of pullComments) {
+      if (comment.user?.login === state.claimant) {
+        latest = laterTimestamp(latest, comment.created_at);
+      }
+    }
+  }
+  return latest;
+}
+
+async function ensureRecoveryNotice(github, coordinates, reason) {
+  const marker = `<!-- moira-issue-claim-recovery:v1 issue=${coordinates.issue_number} -->`;
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    ...coordinates,
+    per_page: 100,
+  });
+  if (comments.some((comment) => isTrustedBot(comment) && comment.body?.includes(marker))) return;
+  await bestEffortComment(
+    github,
+    coordinates,
+    `This managed claim needs maintainer recovery: ${reason}\n\n${marker}`,
+  );
+}
+
+async function reconcileIssue({ github, core, coordinates, now }) {
+  const issue = await getIssue(github, coordinates);
+  const records = await listStateRecords(github, coordinates);
+  if (records.length === 0) {
+    core.warning(
+      `Issue #${coordinates.issue_number} has no managed lease; preserving manual state.`,
+    );
+    return { outcome: "manual" };
+  }
+  if (records.length !== 1 || !records[0] || records[0].invalid) {
+    await ensureRecoveryNotice(github, coordinates, "the trusted lease record is ambiguous");
+    core.setFailed(`Issue #${coordinates.issue_number} has an ambiguous managed lease record.`);
+    return { outcome: "recovery_required" };
+  }
+
+  let record = records[0];
+  let state = record.state;
+  if (state.status !== "active" || !validateClaimed(issue, state.claimant)) {
+    core.warning(`Issue #${coordinates.issue_number} was changed manually; preserving that state.`);
+    return { outcome: "manual_override" };
+  }
+
+  if (state.reminderCleanup) {
+    const cleanup = await finishReminderCleanup({
+      github,
+      core,
+      coordinates,
+      record,
+      state,
+      renewedAt: state.lastActivityAt,
+    });
+    if (!cleanup.complete) return { outcome: "cleanup_pending", state: cleanup.state };
+    record = cleanup.record;
+    state = cleanup.state;
+  }
+
+  const latestActivity = await findLatestAllowedActivity(github, coordinates, state);
+  if (Date.parse(latestActivity) > Date.parse(state.lastActivityAt)) {
+    const renewed = {
+      ...state,
+      lastActivityAt: latestActivity,
+      activityDeadlineAt: addDays(latestActivity, ACTIVE_LEASE_DAYS),
+      remindedAt: null,
+      reminderCleanup: reminderCleanupFor(state),
+    };
+    const parsed = await updateLeaseState(
+      github,
+      coordinates,
+      record,
+      renewed,
+      renderActiveState(renewed),
+    );
+    const cleanup = await finishReminderCleanup({
+      github,
+      core,
+      coordinates,
+      record: parsed,
+      state: renewed,
+      renewedAt: latestActivity,
+    });
+    return {
+      outcome: cleanup.complete ? "renewed" : "renewed_cleanup_pending",
+      state: cleanup.state,
+    };
+  }
+
+  if (Date.parse(now) < Date.parse(state.activityDeadlineAt)) {
+    return { outcome: "active", state };
+  }
+
+  const reminders = await listReminderRecords(github, coordinates, state);
+  if (reminders.length > 1) {
+    await ensureRecoveryNotice(github, coordinates, "multiple trusted reminders exist");
+    core.setFailed(`Issue #${coordinates.issue_number} has duplicate reminder records.`);
+    return { outcome: "recovery_required" };
+  }
+
+  if (state.remindedAt === null) {
+    let reminder = reminders[0];
+    if (!reminder) {
+      const response = await github.rest.issues.createComment({
+        ...coordinates,
+        body: [
+          `@${state.claimant}, this claim has reached its inactivity deadline.`,
+          "",
+          "The exact release-eligibility time is being recorded from this GitHub comment.",
+          "",
+          reminderMarker(state),
+        ].join("\n"),
+      });
+      reminder = response.data;
+      if (!isTrustedBot(reminder) || !reminder.body?.includes(reminderMarker(state))) {
+        throw new TransitionError("GitHub did not persist a trusted reminder.", "reminder_failed");
+      }
+    }
+    const finalReminder = await github.rest.issues.updateComment({
+      ...coordinates,
+      comment_id: reminder.id,
+      body: renderReminder(state, addDays(reminder.created_at, REMINDER_GRACE_DAYS)),
+    });
+    reminder = finalReminder.data;
+    if (!isTrustedBot(reminder) || !reminder.body?.includes(reminderMarker(state))) {
+      throw new TransitionError("GitHub did not finalize the trusted reminder.", "reminder_failed");
+    }
+    state = { ...state, remindedAt: reminder.created_at, reminderCleanup: null };
+    await updateLeaseState(github, coordinates, record, state, renderRemindedState(state));
+    return { outcome: "reminded", state };
+  }
+
+  if (
+    reminders.length !== 1 ||
+    reminders[0].created_at !== state.remindedAt ||
+    !isTrustedBot(reminders[0])
+  ) {
+    await ensureRecoveryNotice(github, coordinates, "the reminder timestamp cannot be verified");
+    core.setFailed(`Issue #${coordinates.issue_number} has an unverifiable reminder.`);
+    return { outcome: "recovery_required" };
+  }
+
+  const releaseEligibleAt = addDays(state.remindedAt, REMINDER_GRACE_DAYS);
+  if (Date.parse(now) < Date.parse(releaseEligibleAt)) {
+    return { outcome: "grace", state, releaseEligibleAt };
+  }
+
+  // Re-read both product state and activity immediately before the destructive release transition.
+  const currentIssue = await getIssue(github, coordinates);
+  const currentRecords = await listStateRecords(github, coordinates);
+  if (
+    currentRecords.length !== 1 ||
+    !currentRecords[0] ||
+    currentRecords[0].invalid ||
+    currentRecords[0].state.generation !== state.generation ||
+    currentRecords[0].state.remindedAt !== state.remindedAt ||
+    !validateClaimed(currentIssue, state.claimant)
+  ) {
+    core.warning(`Issue #${coordinates.issue_number} changed before expiry; preserving it.`);
+    return { outcome: "manual_override" };
+  }
+  const activityBeforeRelease = await findLatestAllowedActivity(github, coordinates, state);
+  if (Date.parse(activityBeforeRelease) > Date.parse(state.lastActivityAt)) {
+    const renewed = {
+      ...state,
+      lastActivityAt: activityBeforeRelease,
+      activityDeadlineAt: addDays(activityBeforeRelease, ACTIVE_LEASE_DAYS),
+      remindedAt: null,
+      reminderCleanup: reminderCleanupFor(state),
+    };
+    const parsed = await updateLeaseState(
+      github,
+      coordinates,
+      currentRecords[0],
+      renewed,
+      renderActiveState(renewed),
+    );
+    const cleanup = await finishReminderCleanup({
+      github,
+      core,
+      coordinates,
+      record: parsed,
+      state: renewed,
+      renewedAt: activityBeforeRelease,
+    });
+    return {
+      outcome: cleanup.complete ? "renewed" : "renewed_cleanup_pending",
+      state: cleanup.state,
+    };
+  }
+
+  return releaseIssue({
+    github,
+    core,
+    coordinates,
+    claimant: state.claimant,
+    releaseReason: "released after the inactivity reminder and grace period",
+  });
+}
+
+async function listClaimedIssueNumbers({ github, context }) {
+  const requested = context.payload.inputs?.issue_number;
+  if (requested !== undefined && requested !== "") {
+    const issueNumber = Number(requested);
+    if (!Number.isSafeInteger(issueNumber) || issueNumber <= 0) {
+      throw new TransitionError("issue_number must be a positive integer.", "invalid_issue_number");
+    }
+    return [issueNumber];
+  }
+  const issues = await github.paginate(github.rest.issues.listForRepo, {
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    state: "open",
+    labels: IN_PROGRESS_STATUS,
+    per_page: 100,
+  });
+  return issues.filter((issue) => !issue.pull_request).map((issue) => issue.number);
+}
+
+async function commandWasProcessed(github, coordinates, commentId) {
+  const reactions = await github.paginate(github.rest.reactions.listForIssueComment, {
+    owner: coordinates.owner,
+    repo: coordinates.repo,
+    comment_id: commentId,
+    per_page: 100,
+  });
+  return reactions.some(
+    (reaction) => isTrustedBot(reaction) && reaction.content === PROCESSED_REACTION,
+  );
+}
+
+async function markCommandProcessed(github, coordinates, commentId) {
+  const response = await github.rest.reactions.createForIssueComment({
+    owner: coordinates.owner,
+    repo: coordinates.repo,
+    comment_id: commentId,
+    content: PROCESSED_REACTION,
+  });
+  if (!isTrustedBot(response.data) || response.data.content !== PROCESSED_REACTION) {
+    throw new TransitionError(
+      `GitHub did not persist the processed marker for comment ${commentId}.`,
+      "processed_marker_failed",
+    );
+  }
+}
+
+async function commandAlreadyApplied(github, coordinates, comment) {
+  const records = await listStateRecords(github, coordinates);
+  if (
+    records.length !== 1 ||
+    !records[0] ||
+    records[0].invalid ||
+    records[0].state.lastCompletedCommandId !== comment.id
+  ) {
+    return false;
+  }
+  const issue = await getIssue(github, coordinates);
+  const command = parseCommand(comment.body);
+  if (command === CLAIM_COMMAND) {
+    return (
+      records[0].state.status === "active" &&
+      records[0].state.claimant === comment.user?.login &&
+      validateClaimed(issue, records[0].state.claimant)
+    );
+  }
+  if (command === RELEASE_COMMAND) {
+    const statuses = statusLabels(issue);
+    return (
+      records[0].state.status === "released" &&
+      issue.assignees.length === 0 &&
+      statuses.length === 1 &&
+      statuses[0] === READY_STATUS
+    );
+  }
+  return false;
+}
+
+async function drainIssueCommands({ github, context, core, coordinates }) {
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    ...coordinates,
+    per_page: 100,
+  });
+  const commands = comments
+    .filter((comment) => parseCommand(comment.body) !== null)
+    .sort((left, right) => {
+      const timeDifference = Date.parse(left.created_at) - Date.parse(right.created_at);
+      return timeDifference || left.id - right.id;
+    });
+  const outcomes = [];
+
+  for (const comment of commands) {
+    if (await commandWasProcessed(github, coordinates, comment.id)) continue;
+    if (await commandAlreadyApplied(github, coordinates, comment)) {
+      await markCommandProcessed(github, coordinates, comment.id);
+      outcomes.push({ commentId: comment.id, result: { outcome: "processed_marker_recovered" } });
+      continue;
+    }
+    const syntheticContext = {
+      ...context,
+      payload: {
+        ...context.payload,
+        issue: { number: coordinates.issue_number },
+        comment,
+      },
+    };
+    const result = await handleIssueComment({ github, context: syntheticContext, core });
+    await markCommandProcessed(github, coordinates, comment.id);
+    outcomes.push({ commentId: comment.id, result });
+  }
+  return outcomes;
+}
+
+async function handleIssueEvent({ github, context, core }) {
+  const event = context.payload;
+  if (event.issue.pull_request) return { outcome: "ignored" };
+  const coordinates = {
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: event.issue.number,
+  };
+  const commands = await drainIssueCommands({ github, context, core, coordinates });
+  if (parseCommand(event.comment?.body) !== null) {
+    return { outcome: "commands_drained", commands };
+  }
+  const renewal = await renewLease({
+    github,
+    core,
+    coordinates,
+    actor: event.comment.user.login,
+    activityAt: event.comment.created_at,
+  });
+  return { outcome: "commands_drained", commands, renewal };
+}
+
+async function handleIssueComment({ github, context, core }) {
+  const event = context.payload;
+  const command = parseCommand(event.comment?.body);
+  const coordinates = {
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: event.issue.number,
+  };
+  const claimant = event.comment.user.login;
+
+  if (!command) {
+    if (event.issue.pull_request) return { outcome: "ignored" };
+    return renewLease({
+      github,
+      core,
+      coordinates,
+      actor: claimant,
+      activityAt: event.comment.created_at,
+    });
+  }
+
+  if (event.issue.pull_request) {
+    await createRequiredComment(
+      github,
+      coordinates,
+      `@${claimant}, issue claim commands do not run on pull requests.`,
+    );
+    return { outcome: "rejected", reason: "pull_request" };
+  }
+  if (command === "invalid") {
+    await createRequiredComment(
+      github,
+      coordinates,
+      `@${claimant}, use exactly \`${CLAIM_COMMAND}\` or \`${RELEASE_COMMAND}\` on its own line.`,
+    );
+    return { outcome: "rejected", reason: "invalid_command" };
+  }
+
+  if (command === CLAIM_COMMAND) {
+    return claimIssue({
+      github,
+      core,
+      coordinates,
+      claimant,
+      activityAt: event.comment.created_at,
+      triggerCommentId: event.comment.id,
+    });
+  }
+  return releaseIssue({
+    github,
+    core,
+    coordinates,
+    claimant,
+    releaseCommandId: event.comment.id,
+  });
+}
+
+module.exports = {
+  ACTIVE_LEASE_DAYS,
+  ALLOWED_TYPES,
+  CLAIM_COMMAND,
+  IN_PROGRESS_STATUS,
+  KNOWN_STATUSES,
+  KNOWN_TYPES,
+  PROCESSED_REACTION,
+  READY_STATUS,
+  RELEASE_COMMAND,
+  REMINDER_GRACE_DAYS,
+  REMINDER_MARKER,
+  STATE_MARKER,
+  TRUSTED_BOT_ID,
+  TRUSTED_BOT_LOGIN,
+  TransitionError,
+  addDays,
+  bestEffortComment,
+  claimIssue,
+  clearReminderRecords,
+  commandWasProcessed,
+  commandAlreadyApplied,
+  createRequiredComment,
+  drainIssueCommands,
+  ensureRecoveryNotice,
+  findLatestAllowedActivity,
+  finishReminderCleanup,
+  getClosingPullRequest,
+  handleIssueEvent,
+  handleIssueComment,
+  isTrustedBot,
+  listClaimedIssueNumbers,
+  listCrossReferencedPullRequestNumbers,
+  listReminderRecords,
+  listStateRecords,
+  markCommandProcessed,
+  normalizeLabels,
+  parseCommand,
+  parseStateComment,
+  reconcileIssue,
+  releaseIssue,
+  renderActiveState,
+  renderClearedReminder,
+  renderRemindedState,
+  renderReminder,
+  renderReleasedState,
+  reminderMarker,
+  reminderCleanupFor,
+  renewLease,
+  stateMarker,
+  statusLabels,
+  transitionStatus,
+  validateClaimable,
+  validateClaimed,
+};

--- a/.github/workflows/issue-claims.yml
+++ b/.github/workflows/issue-claims.yml
@@ -1,0 +1,115 @@
+name: Issue claims
+
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    - cron: "23 4 * * *"
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Reconcile one issue instead of all in-progress issues
+        required: false
+        type: number
+
+permissions: {}
+
+jobs:
+  command:
+    if: github.event_name == 'issue_comment' && github.event.issue.pull_request == null
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    concurrency:
+      group: issue-claim-${{ github.repository }}-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    steps:
+      - name: Check out trusted default-branch automation
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Process issue command
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const coordinator = require('./.github/scripts/issue-claim.cjs');
+            await coordinator.handleIssueEvent({ github, context, core });
+
+  lease_discovery:
+    name: Discover claim leases
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      issue_numbers: ${{ steps.discover.outputs.result }}
+    steps:
+      - name: Check out trusted default-branch automation
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Discover claims to reconcile
+        id: discover
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const coordinator = require('./.github/scripts/issue-claim.cjs');
+            return coordinator.listClaimedIssueNumbers({ github, context });
+
+  lease_reconciliation:
+    name: Reconcile claim lease for #${{ matrix.issue_number }}
+    needs: lease_discovery
+    if: needs.lease_discovery.outputs.issue_numbers != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        issue_number: ${{ fromJSON(needs.lease_discovery.outputs.issue_numbers) }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    concurrency:
+      group: issue-claim-${{ github.repository }}-${{ matrix.issue_number }}
+      cancel-in-progress: false
+    steps:
+      - name: Check out trusted default-branch automation
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Reconcile claim lease
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          ISSUE_NUMBER: ${{ matrix.issue_number }}
+        with:
+          script: |
+            const coordinator = require('./.github/scripts/issue-claim.cjs');
+            await coordinator.drainIssueCommands({
+              github,
+              context,
+              core,
+              coordinates: {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: Number(process.env.ISSUE_NUMBER),
+              },
+            });
+            await coordinator.reconcileIssue({
+              github,
+              core,
+              coordinates: {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: Number(process.env.ISSUE_NUMBER),
+              },
+              now: new Date().toISOString(),
+            });

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,12 @@
 Agent guide for the Moira repository. Read this before making changes. Claude Code
 reads `CLAUDE.md`, which imports this file with `@AGENTS.md`.
 
+Before beginning any development work, read `CONTRIBUTING.md` completely. It is the
+source of truth for coordinating work through GitHub issues, claiming or releasing
+an issue, pull-request linkage, and the contributor/maintainer handoff. Do not start
+implementation from an issue until that contract says the issue is available and
+the claim has been confirmed.
+
 ## What Moira Is
 
 Moira is a node-graph **Agent Workflow Engine**. It guides AI agents (Claude, GPT,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,14 +38,116 @@ npm run test:unit        # unit tests (no Docker needed)
 
 See `tests/TESTING-GUIDE.md` for details on the test categories.
 
+## Coordinate work through an issue
+
+Before starting substantial implementation, find or open a GitHub issue and wait
+until maintainers have made it claimable. An issue is claimable only when all of
+these conditions are visible at the same time:
+
+- it is open and is an issue, not a pull request;
+- it has no assignee;
+- it has exactly one status label, `status:ready`;
+- it has exactly one implementation type: `type:bug`, `type:feature`,
+  `type:chore`, or `type:docs`.
+
+Epics, questions, and issues waiting for triage, investigation, design, author
+input, a dependency, or current implementation are not claimable. Missing,
+unknown, duplicate, or contradictory `status:*` or `type:*` labels require maintainer
+recovery; do not guess which state was intended.
+
+### Claim an issue
+
+Add a comment containing exactly:
+
+```text
+/claim
+```
+
+The repository automation serializes changes for that issue and rechecks its
+current state. A successful claim has both of these public signals:
+
+- you are the issue's only assignee;
+- its only status is `status:in-progress`.
+
+The bot also publishes a confirmation naming you and the absolute activity
+deadline. Do not treat the issue as yours unless that confirmation appears. A
+rejection explains whether the issue is occupied, not ready, inconsistent, or
+requires maintainer recovery. A failed partial transition is rolled back when it
+is still safe; ambiguous external changes are preserved for a maintainer instead
+of being overwritten.
+
+### Keep the claim active
+
+The activity deadline is seven days after the latest qualifying activity. Only
+GitHub events attributable to the current assignee qualify:
+
+- a comment on the claimed issue, except `/release`;
+- opening a pull request in this repository that GitHub links to the issue through
+  a closing keyword such as `Closes #123` or `Fixes #123`;
+- a comment by the assignee on that closing-linked pull request.
+
+General pull-request `updated_at` changes do not qualify. Commits/pushes,
+synchronize or base-branch events, CI/check activity, reviews, reactions, labels,
+assignments, bot activity, other people's comments, cross-repository pull
+requests, and issue mentions without a closing reference do not renew a claim.
+Post a concise progress comment when in doubt.
+
+After seven inactive days, the next successful scheduled reconciliation posts one
+reminder. The three-day grace period starts at the trusted GitHub timestamp of
+that actual reminder, not at the original deadline. If no qualifying activity
+appears, the first successful reconciliation after the grace period releases the
+claim. GitHub Actions schedules can be delayed, so these are minimum intervals,
+not an exact promised release time. Later qualifying activity clears the reminder
+and starts a new seven-day activity period.
+
+### Release an issue
+
+If you stop working on a claimed issue, add a comment containing exactly:
+
+```text
+/release
+```
+
+Only the current sole assignee can release a managed claim. A successful release
+removes the assignee and changes the sole status back to `status:ready`. If a
+release cannot be completed safely, the bot either restores the active claim or
+marks it for maintainer recovery; never assume that a failed command released it.
+
+### Maintainer recovery and overrides
+
+Maintainer changes are authoritative. The automation does not replace a newer
+assignee or contradictory status merely to satisfy its previous lease record. An
+in-progress issue without a trusted bot lease record is treated as manually
+managed and is not expired automatically.
+
+To recover a damaged or partially applied managed claim:
+
+1. Coordinate with the visible assignee before changing ownership.
+2. Leave exactly one appropriate `status:*` and at most one intended assignee.
+3. Delete obsolete bot comments containing `moira-issue-claim-state:v1`,
+   `moira-issue-claim-reminder:v1`, or `moira-issue-claim-recovery:v1` when their
+   recorded owner no longer matches the intended state.
+4. For an available issue, leave it unassigned with `status:ready`; the next
+   contributor can run `/claim`. To preserve manual ownership, leave one assignee
+   with `status:in-progress`; it will not receive automatic lease expiry without a
+   managed state record.
+5. Run the **Issue claims** workflow manually with the issue number to verify a
+   repaired managed claim or inspect the failed workflow logs for the guarded API
+   boundary.
+
+Assignees are the ownership source of truth. `status:in-progress` communicates the
+lifecycle state but must not be used by itself to reserve work.
+
 ## Making changes
 
-1. Fork the repository and create a feature branch from `master`.
-2. Make your changes, keeping them focused and well-scoped.
-3. Add or update tests for any behavior change.
-4. Run the test suite and make sure it passes.
-5. Update documentation if you changed user-facing behavior.
-6. Open a pull request against `master` describing what and why.
+1. Claim a ready issue and wait for the bot's successful confirmation.
+2. Fork the repository and create a feature branch from `master`.
+3. Make your changes, keeping them focused and well-scoped.
+4. Add or update tests for any behavior change.
+5. Run the test suite and make sure it passes.
+6. Update documentation if you changed user-facing behavior.
+7. Open a pull request against `master`, use a closing reference to the claimed
+   issue, and describe what and why.
 
 ## Sign your commits (DCO)
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -62,7 +62,15 @@ export default [
   },
   // Tests - relaxed rules
   {
-    files: ["tests/**/*.ts", "tests/**/*.tsx", "tests/**/*.js", "**/*.test.ts", "**/*.spec.ts"],
+    files: [
+      "tests/**/*.ts",
+      "tests/**/*.tsx",
+      "tests/**/*.js",
+      "tests/**/*.cjs",
+      "**/*.test.ts",
+      "**/*.test.cjs",
+      "**/*.spec.ts",
+    ],
     languageOptions: {
       globals: {
         ...globals.node,
@@ -74,6 +82,7 @@ export default [
     rules: {
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-require-imports": "off",
       "no-console": "off",
       "no-restricted-syntax": "off",
     },
@@ -107,6 +116,22 @@ export default [
       },
     },
     rules: {
+      "no-console": "off",
+      "no-restricted-syntax": "off",
+    },
+  },
+  // GitHub Actions helpers execute as CommonJS under actions/github-script.
+  {
+    files: [".github/scripts/**/*.cjs"],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+        console: "readonly",
+        process: "readonly",
+      },
+    },
+    rules: {
+      "@typescript-eslint/no-require-imports": "off",
       "no-console": "off",
       "no-restricted-syntax": "off",
     },

--- a/tests/COVERAGE-MAP.md
+++ b/tests/COVERAGE-MAP.md
@@ -314,6 +314,14 @@ level headings classify the tracked test paths listed beneath them.
 
 - `tests/mcp-tools/workflow-upload-visibility.test.ts`
 
+### github-collaboration
+
+**unit**
+
+- `tests/unit/github/issue-claim-transitions.test.cjs` — exact command parsing, centralized claim eligibility, ordered coalescing-safe command draining with trusted processed reactions, verified claim/release invariants, trusted human-readable lease record, fault-injected partial/silent GitHub mutations and response replay, ownership-safe compensation, external interleaving preservation, and owner-only release
+- `tests/unit/github/issue-claim-leases.test.cjs` — attributable issue/closing-PR activity, excluded external activity, direct and scheduled renewal, delayed reminder timestamps, retriable visible-reminder cleanup, post-reminder grace, expiry, interrupted/duplicate/malformed record recovery, manual-state preservation, repeat safety, and manual discovery targeting
+- `tests/unit/github/issue-claim-workflow-contract.test.cjs` — trusted default-branch checkout, least-privilege permissions, shared per-issue concurrency, command/schedule/manual triggers, and matrix reconciliation wiring
+
 ### health
 
 **e2e**

--- a/tests/TESTING-GUIDE.md
+++ b/tests/TESTING-GUIDE.md
@@ -141,7 +141,9 @@ npm run test:mcp-tools:prod       # MCP on production
 
 ### File Naming
 
-- Unit/Integration/API/MCP: `*.test.ts`
+- Unit/Integration/API/MCP: `*.test.ts`; repository automation that executes as
+  CommonJS in GitHub Actions may use `*.test.cjs` to exercise the shipped module
+  without an interop wrapper.
 - E2E: `*.spec.ts`
 
 ### E2E Import Rule

--- a/tests/config/jest.unit.config.js
+++ b/tests/config/jest.unit.config.js
@@ -4,7 +4,11 @@ import baseConfig from "./jest.base.config.js";
 export default {
   ...baseConfig,
   displayName: "Unit Tests",
-  testMatch: ["<rootDir>/tests/unit/**/*.test.ts", "<rootDir>/tests/unit/**/*.test.tsx"],
+  testMatch: [
+    "<rootDir>/tests/unit/**/*.test.ts",
+    "<rootDir>/tests/unit/**/*.test.tsx",
+    "<rootDir>/tests/unit/**/*.test.cjs",
+  ],
   testTimeout: 30000,
   // Use 50% of CPUs in CI (2 cores = 1 worker), more locally
   maxWorkers: process.env.CI ? "50%" : 6,

--- a/tests/unit/github/issue-claim-leases.test.cjs
+++ b/tests/unit/github/issue-claim-leases.test.cjs
@@ -1,0 +1,449 @@
+"use strict";
+
+const { describe, expect, test } = require("@jest/globals");
+const coordinator = require("../../../.github/scripts/issue-claim.cjs");
+
+const coordinates = { owner: "moira-mcp", repo: "moira", issue_number: 42 };
+
+function user(login, bot = false) {
+  return bot
+    ? { id: coordinator.TRUSTED_BOT_ID, login: coordinator.TRUSTED_BOT_LOGIN, type: "Bot" }
+    : { id: 10, login, type: "User" };
+}
+
+function createHarness({
+  lastActivityAt = "2026-08-01T10:00:00.000Z",
+  githubNow = "2026-08-08T10:00:00.000Z",
+} = {}) {
+  const state = {
+    githubNow,
+    issue: {
+      number: 42,
+      state: "open",
+      labels: [{ name: "type:bug" }, { name: "status:in-progress" }],
+      assignees: [{ login: "alice" }],
+    },
+    comments: { 42: [] },
+    pulls: {},
+    nextCommentId: 100,
+    etag: 1,
+    calls: {},
+    faults: {},
+  };
+  const lease = {
+    version: 1,
+    generation: "42-7",
+    claimant: "alice",
+    status: "active",
+    claimedAt: "2026-08-01T10:00:00.000Z",
+    lastActivityAt,
+    activityDeadlineAt: coordinator.addDays(lastActivityAt, coordinator.ACTIVE_LEASE_DAYS),
+    remindedAt: null,
+    reminderCleanup: null,
+    lastCompletedCommandId: 7,
+  };
+  state.comments[42].push({
+    id: 1,
+    body: coordinator.renderActiveState(lease),
+    created_at: lease.claimedAt,
+    updated_at: lease.claimedAt,
+    user: user(coordinator.TRUSTED_BOT_LOGIN, true),
+  });
+
+  const core = {
+    failures: [],
+    warnings: [],
+    setFailed(message) {
+      this.failures.push(message);
+    },
+    warning(message) {
+      this.warnings.push(message);
+    },
+  };
+  const issueResponse = () => ({
+    data: structuredClone(state.issue),
+    headers: { etag: `"${state.etag}"` },
+  });
+  const hit = (name) => {
+    state.calls[name] = (state.calls[name] || 0) + 1;
+    const fault = state.faults[`${name}:${state.calls[name]}`];
+    if (fault === "throw") throw new Error(`injected ${name}:${state.calls[name]}`);
+    return fault;
+  };
+  const issues = {
+    get: async () => issueResponse(),
+    listComments: async ({ issue_number }) => ({
+      data: structuredClone(state.comments[issue_number] || []),
+    }),
+    createComment: async ({ issue_number, body }) => {
+      const comment = {
+        id: state.nextCommentId++,
+        body,
+        created_at: state.githubNow,
+        updated_at: state.githubNow,
+        user: user(coordinator.TRUSTED_BOT_LOGIN, true),
+      };
+      (state.comments[issue_number] ||= []).push(comment);
+      return { data: structuredClone(comment) };
+    },
+    updateComment: async ({ comment_id, body }) => {
+      hit("updateComment");
+      const comment = Object.values(state.comments)
+        .flat()
+        .find((candidate) => candidate.id === comment_id);
+      if (!comment) throw new Error(`comment ${comment_id} does not exist`);
+      comment.body = body;
+      comment.updated_at = state.githubNow;
+      return { data: structuredClone(comment) };
+    },
+    addLabels: async ({ labels }) => {
+      for (const name of labels) {
+        if (!state.issue.labels.some((label) => label.name === name)) {
+          state.issue.labels.push({ name });
+        }
+      }
+      state.etag += 1;
+      return { data: structuredClone(state.issue.labels) };
+    },
+    removeLabel: async ({ name }) => {
+      state.issue.labels = state.issue.labels.filter((label) => label.name !== name);
+      state.etag += 1;
+      return { data: structuredClone(state.issue.labels) };
+    },
+    removeAssignees: async ({ assignees }) => {
+      state.issue.assignees = state.issue.assignees.filter(
+        (assignee) => !assignees.includes(assignee.login),
+      );
+      state.etag += 1;
+      return issueResponse();
+    },
+    addAssignees: async ({ assignees }) => {
+      state.issue.assignees = assignees.map((login) => ({ login }));
+      state.etag += 1;
+      return issueResponse();
+    },
+    listForRepo: async () => ({ data: [structuredClone(state.issue)] }),
+  };
+  const github = {
+    rest: { issues },
+    paginate: async (method, options) => (await method(options)).data,
+    graphql: async (query, variables) => {
+      if (query.includes("CrossReferencedPullRequests")) {
+        return {
+          repository: {
+            issue: {
+              timelineItems: {
+                nodes: Object.values(state.pulls).map((pull) => ({
+                  source: {
+                    number: pull.number,
+                    repository: { nameWithOwner: pull.repository || "moira-mcp/moira" },
+                  },
+                })),
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+          },
+        };
+      }
+      if (query.includes("ClosingReferences")) {
+        const pull = state.pulls[variables.pullNumber];
+        return {
+          repository: {
+            pullRequest: pull
+              ? {
+                  number: pull.number,
+                  createdAt: pull.createdAt,
+                  author: { login: pull.author },
+                  closingIssuesReferences: {
+                    nodes: pull.closes
+                      ? [{ number: 42, repository: { nameWithOwner: "moira-mcp/moira" } }]
+                      : [],
+                    pageInfo: { hasNextPage: false, endCursor: null },
+                  },
+                }
+              : null,
+          },
+        };
+      }
+      throw new Error("unexpected GraphQL query");
+    },
+  };
+
+  return {
+    state,
+    core,
+    github,
+    addIssueComment(login, createdAt, body = "Progress update") {
+      state.comments[42].push({
+        id: state.nextCommentId++,
+        body,
+        created_at: createdAt,
+        updated_at: createdAt,
+        user: user(login),
+      });
+    },
+    addPull({ number = 50, author = "alice", createdAt, closes = true, repository }) {
+      state.pulls[number] = { number, author, createdAt, closes, repository };
+      state.comments[number] = [];
+      return number;
+    },
+    addPullComment(number, login, createdAt) {
+      state.comments[number].push({
+        id: state.nextCommentId++,
+        body: "PR progress",
+        created_at: createdAt,
+        updated_at: createdAt,
+        user: user(login),
+      });
+    },
+    leaseState() {
+      return coordinator.parseStateComment(state.comments[42][0]).state;
+    },
+    reminderComments() {
+      return state.comments[42].filter((comment) =>
+        comment.body.includes(coordinator.REMINDER_MARKER),
+      );
+    },
+  };
+}
+
+async function reconcile(harness, now = harness.state.githubNow) {
+  harness.state.githubNow = now;
+  return coordinator.reconcileIssue({
+    github: harness.github,
+    core: harness.core,
+    coordinates,
+    now,
+  });
+}
+
+describe("managed issue claim leases", () => {
+  test("uses the actual delayed reminder time and preserves the full grace period", async () => {
+    const harness = createHarness({ githubNow: "2026-08-10T10:00:00.000Z" });
+
+    expect((await reconcile(harness)).outcome).toBe("reminded");
+    expect(harness.leaseState().remindedAt).toBe("2026-08-10T10:00:00.000Z");
+    expect(harness.reminderComments()[0].body).toContain("2026-08-13T10:00:00.000Z");
+    expect((await reconcile(harness, "2026-08-12T10:00:00.000Z")).outcome).toBe("grace");
+    expect(harness.reminderComments()).toHaveLength(1);
+
+    expect((await reconcile(harness, "2026-08-13T10:00:00.000Z")).outcome).toBe("released");
+    expect(harness.state.issue.assignees).toEqual([]);
+    expect(harness.state.issue.labels.map((label) => label.name)).toContain("status:ready");
+  });
+
+  test("does nothing before the activity deadline", async () => {
+    const harness = createHarness({ githubNow: "2026-08-07T09:59:59.000Z" });
+    expect((await reconcile(harness)).outcome).toBe("active");
+    expect(harness.reminderComments()).toHaveLength(0);
+  });
+
+  test("renews from an attributable issue comment and clears an earlier reminder", async () => {
+    const harness = createHarness({ githubNow: "2026-08-10T10:00:00.000Z" });
+    expect((await reconcile(harness)).outcome).toBe("reminded");
+    harness.addIssueComment("alice", "2026-08-11T12:00:00.000Z");
+
+    expect((await reconcile(harness, "2026-08-13T10:00:00.000Z")).outcome).toBe("renewed");
+    expect(harness.leaseState()).toMatchObject({
+      lastActivityAt: "2026-08-11T12:00:00.000Z",
+      activityDeadlineAt: "2026-08-18T12:00:00.000Z",
+      remindedAt: null,
+    });
+    expect(harness.reminderComments()[0].body).toContain("was cleared by qualifying activity");
+
+    expect((await reconcile(harness, "2026-08-18T12:00:00.000Z")).outcome).toBe("reminded");
+    expect(harness.reminderComments()).toHaveLength(2);
+    expect(harness.leaseState().remindedAt).toBe("2026-08-18T12:00:00.000Z");
+  });
+
+  test("retries reminder cleanup after its comment update fails", async () => {
+    const harness = createHarness({ githubNow: "2026-08-10T10:00:00.000Z" });
+    expect((await reconcile(harness)).outcome).toBe("reminded");
+    harness.addIssueComment("alice", "2026-08-11T12:00:00.000Z");
+    harness.state.faults["updateComment:4"] = "throw";
+
+    expect((await reconcile(harness, "2026-08-13T10:00:00.000Z")).outcome).toBe(
+      "renewed_cleanup_pending",
+    );
+    expect(harness.leaseState().reminderCleanup).toMatchObject({
+      generation: "42-7",
+      lastActivityAt: "2026-08-01T10:00:00.000Z",
+    });
+    expect(harness.reminderComments()[0].body).not.toContain("was cleared by qualifying activity");
+
+    delete harness.state.faults["updateComment:4"];
+    expect((await reconcile(harness, "2026-08-14T10:00:00.000Z")).outcome).toBe("active");
+    expect(harness.leaseState().reminderCleanup).toBeNull();
+    expect(harness.reminderComments()[0].body).toContain("was cleared by qualifying activity");
+    expect(harness.core.warnings).toHaveLength(1);
+  });
+
+  test("finishes pending reminder cleanup before releasing the claim", async () => {
+    const harness = createHarness({ githubNow: "2026-08-10T10:00:00.000Z" });
+    expect((await reconcile(harness)).outcome).toBe("reminded");
+    harness.addIssueComment("alice", "2026-08-11T12:00:00.000Z");
+    harness.state.faults["updateComment:4"] = "throw";
+    expect((await reconcile(harness, "2026-08-13T10:00:00.000Z")).outcome).toBe(
+      "renewed_cleanup_pending",
+    );
+    delete harness.state.faults["updateComment:4"];
+
+    const released = await coordinator.releaseIssue({
+      github: harness.github,
+      core: harness.core,
+      coordinates,
+      claimant: "alice",
+      releaseCommandId: 777,
+    });
+
+    expect(released.outcome).toBe("released");
+    expect(harness.state.issue.assignees).toEqual([]);
+    expect(harness.reminderComments()[0].body).toContain("was cleared by qualifying activity");
+    expect(harness.leaseState()).toMatchObject({
+      status: "released",
+      reminderCleanup: null,
+      lastCompletedCommandId: 777,
+    });
+  });
+
+  test("renews immediately when the current assignee comments on the issue", async () => {
+    const harness = createHarness();
+    const result = await coordinator.renewLease({
+      github: harness.github,
+      core: harness.core,
+      coordinates,
+      actor: "alice",
+      activityAt: "2026-08-04T10:00:00.000Z",
+    });
+    expect(result.outcome).toBe("renewed");
+    expect(harness.leaseState().activityDeadlineAt).toBe("2026-08-11T10:00:00.000Z");
+  });
+
+  test("renews from owner-attributable opening and comments on a closing-linked PR", async () => {
+    const opened = createHarness();
+    opened.addPull({ createdAt: "2026-08-05T10:00:00.000Z" });
+    expect((await reconcile(opened)).outcome).toBe("renewed");
+    expect(opened.leaseState().lastActivityAt).toBe("2026-08-05T10:00:00.000Z");
+
+    const commented = createHarness({ lastActivityAt: "2026-08-05T10:00:00.000Z" });
+    const pull = commented.addPull({ createdAt: "2026-08-01T09:00:00.000Z" });
+    commented.addPullComment(pull, "alice", "2026-08-06T10:00:00.000Z");
+    expect((await reconcile(commented)).outcome).toBe("renewed");
+    expect(commented.leaseState().lastActivityAt).toBe("2026-08-06T10:00:00.000Z");
+  });
+
+  test.each([
+    [
+      "bot issue comment",
+      (harness) => harness.addIssueComment("github-actions[bot]", "2026-08-07T10:00:00.000Z"),
+    ],
+    [
+      "maintainer issue comment",
+      (harness) => harness.addIssueComment("maintainer", "2026-08-07T10:00:00.000Z"),
+    ],
+    [
+      "release command",
+      (harness) => harness.addIssueComment("alice", "2026-08-07T10:00:00.000Z", "/release"),
+    ],
+    [
+      "mention-only PR",
+      (harness) => harness.addPull({ createdAt: "2026-08-07T10:00:00.000Z", closes: false }),
+    ],
+    [
+      "other author's PR",
+      (harness) => harness.addPull({ createdAt: "2026-08-07T10:00:00.000Z", author: "reviewer" }),
+    ],
+    [
+      "reviewer PR comment",
+      (harness) => {
+        const number = harness.addPull({ createdAt: "2026-07-01T10:00:00.000Z" });
+        harness.addPullComment(number, "reviewer", "2026-08-07T10:00:00.000Z");
+      },
+    ],
+    [
+      "foreign-repository PR",
+      (harness) =>
+        harness.addPull({
+          createdAt: "2026-08-07T10:00:00.000Z",
+          repository: "someone/fork",
+        }),
+    ],
+  ])("does not renew from %s", async (_name, configure) => {
+    const harness = createHarness();
+    configure(harness);
+    expect((await reconcile(harness)).outcome).toBe("reminded");
+    expect(harness.leaseState().lastActivityAt).toBe("2026-08-01T10:00:00.000Z");
+  });
+
+  test("recovers an interrupted reminder update without creating a second reminder", async () => {
+    const harness = createHarness({ githubNow: "2026-08-10T10:00:00.000Z" });
+    const state = harness.leaseState();
+    harness.state.comments[42].push({
+      id: 555,
+      body: `Interrupted reminder\n\n${coordinator.reminderMarker(state)}`,
+      created_at: "2026-08-10T10:00:00.000Z",
+      updated_at: "2026-08-10T10:00:00.000Z",
+      user: user(coordinator.TRUSTED_BOT_LOGIN, true),
+    });
+    expect((await reconcile(harness)).outcome).toBe("reminded");
+    expect(harness.reminderComments()).toHaveLength(1);
+  });
+
+  test("fails closed for duplicate reminders and malformed state", async () => {
+    const duplicate = createHarness();
+    expect((await reconcile(duplicate)).outcome).toBe("reminded");
+    duplicate.state.comments[42].push({
+      ...structuredClone(duplicate.reminderComments()[0]),
+      id: 999,
+    });
+    expect((await reconcile(duplicate, "2026-08-12T10:00:00.000Z")).outcome).toBe(
+      "recovery_required",
+    );
+    expect(duplicate.core.failures).toHaveLength(1);
+
+    const malformed = createHarness();
+    malformed.state.comments[42][0].body = `<!-- ${coordinator.STATE_MARKER} {broken} -->`;
+    expect((await reconcile(malformed)).outcome).toBe("recovery_required");
+    expect(malformed.state.issue.assignees).toEqual([{ login: "alice" }]);
+  });
+
+  test("preserves manual ownership and unmanaged in-progress issues", async () => {
+    const changed = createHarness();
+    changed.state.issue.assignees = [{ login: "maintainer-choice" }];
+    expect((await reconcile(changed)).outcome).toBe("manual_override");
+    expect(changed.state.issue.assignees).toEqual([{ login: "maintainer-choice" }]);
+
+    const unmanaged = createHarness();
+    unmanaged.state.comments[42] = [];
+    expect((await reconcile(unmanaged)).outcome).toBe("manual");
+    expect(unmanaged.state.issue.assignees).toEqual([{ login: "alice" }]);
+  });
+
+  test("discovers all in-progress issues or one validated manual target", async () => {
+    const harness = createHarness();
+    await expect(
+      coordinator.listClaimedIssueNumbers({
+        github: harness.github,
+        context: { repo: { owner: "moira-mcp", repo: "moira" }, payload: {} },
+      }),
+    ).resolves.toEqual([42]);
+    await expect(
+      coordinator.listClaimedIssueNumbers({
+        github: harness.github,
+        context: {
+          repo: { owner: "moira-mcp", repo: "moira" },
+          payload: { inputs: { issue_number: "91" } },
+        },
+      }),
+    ).resolves.toEqual([91]);
+    await expect(
+      coordinator.listClaimedIssueNumbers({
+        github: harness.github,
+        context: {
+          repo: { owner: "moira-mcp", repo: "moira" },
+          payload: { inputs: { issue_number: "invalid" } },
+        },
+      }),
+    ).rejects.toThrow("positive integer");
+  });
+});

--- a/tests/unit/github/issue-claim-transitions.test.cjs
+++ b/tests/unit/github/issue-claim-transitions.test.cjs
@@ -1,0 +1,653 @@
+"use strict";
+
+const { describe, expect, test } = require("@jest/globals");
+const coordinator = require("../../../.github/scripts/issue-claim.cjs");
+
+const coordinates = { owner: "moira-mcp", repo: "moira", issue_number: 42 };
+
+function createHarness() {
+  const state = {
+    issue: {
+      number: 42,
+      state: "open",
+      labels: [{ name: "type:bug" }, { name: "status:ready" }, { name: "component:cli" }],
+      assignees: [],
+    },
+    comments: [],
+    reactions: {},
+    nextCommentId: 100,
+    etag: 1,
+  };
+  const calls = {};
+  const faults = {};
+  const core = {
+    failures: [],
+    warnings: [],
+    setFailed(message) {
+      this.failures.push(message);
+    },
+    warning(message) {
+      this.warnings.push(message);
+    },
+  };
+  const hit = (name) => {
+    calls[name] = (calls[name] || 0) + 1;
+    const fault = faults[`${name}:${calls[name]}`];
+    if (fault === "throw") throw new Error(`injected ${name}:${calls[name]}`);
+    return fault;
+  };
+  const issueResponse = () => ({
+    data: structuredClone(state.issue),
+    headers: { etag: `"${state.etag}"` },
+  });
+  const botComment = (body, trusted = true) => ({
+    id: state.nextCommentId++,
+    body,
+    created_at: "2026-08-24T10:00:00.000Z",
+    updated_at: "2026-08-24T10:00:00.000Z",
+    user: trusted
+      ? {
+          id: coordinator.TRUSTED_BOT_ID,
+          login: coordinator.TRUSTED_BOT_LOGIN,
+          type: "Bot",
+        }
+      : { id: 999, login: "other-bot[bot]", type: "Bot" },
+  });
+  const issues = {
+    get: async () => {
+      const fault = hit("get");
+      if (fault === "extra-label") state.issue.labels.push({ name: "component:external" });
+      if (fault === "add-maintainer") {
+        state.issue.assignees.push({ login: "maintainer-choice" });
+      }
+      if (fault === "replace-with-maintainer") {
+        state.issue.assignees = [{ login: "maintainer-choice" }];
+      }
+      return issueResponse();
+    },
+    addAssignees: async ({ assignees }) => {
+      const fault = hit("addAssignees");
+      if (fault !== "silent") state.issue.assignees = assignees.map((login) => ({ login }));
+      state.etag += 1;
+      return issueResponse();
+    },
+    removeAssignees: async ({ assignees }) => {
+      const fault = hit("removeAssignees");
+      if (fault !== "silent") {
+        state.issue.assignees = state.issue.assignees.filter(
+          (assignee) => !assignees.includes(assignee.login),
+        );
+      }
+      if (fault === "add-maintainer-after") {
+        state.issue.assignees.push({ login: "maintainer-choice" });
+      }
+      state.etag += 1;
+      return issueResponse();
+    },
+    addLabels: async ({ labels }) => {
+      const fault = hit("addLabels");
+      if (fault === "component-before") state.issue.labels.push({ name: "component:external" });
+      if (fault === "status-blocked-before") {
+        state.issue.labels = state.issue.labels
+          .filter((label) => !label.name.startsWith("status:"))
+          .concat({ name: "status:blocked" });
+      }
+      if (fault !== "silent") {
+        for (const name of labels) {
+          if (!state.issue.labels.some((label) => label.name === name)) {
+            state.issue.labels.push({ name });
+          }
+        }
+      }
+      state.etag += 1;
+      return { data: structuredClone(state.issue.labels) };
+    },
+    removeLabel: async ({ name }) => {
+      const fault = hit("removeLabel");
+      if (fault !== "silent") {
+        state.issue.labels = state.issue.labels.filter((label) => label.name !== name);
+      }
+      state.etag += 1;
+      return { data: structuredClone(state.issue.labels) };
+    },
+    listComments: async () => {
+      hit("listComments");
+      return { data: structuredClone(state.comments) };
+    },
+    createComment: async ({ body }) => {
+      const fault = hit("createComment");
+      const comment = botComment(body, fault !== "untrusted");
+      state.comments.push(comment);
+      return { data: structuredClone(comment) };
+    },
+    updateComment: async ({ comment_id, body }) => {
+      const fault = hit("updateComment");
+      const comment = state.comments.find((candidate) => candidate.id === comment_id);
+      if (!comment) throw new Error(`comment ${comment_id} does not exist`);
+      if (fault !== "silent") comment.body = body;
+      if (fault === "untrusted") comment.user = { id: 999, login: "other-bot[bot]", type: "Bot" };
+      return { data: structuredClone(comment) };
+    },
+  };
+  const reactions = {
+    listForIssueComment: async ({ comment_id }) => {
+      hit("listReactions");
+      return { data: structuredClone(state.reactions[comment_id] || []) };
+    },
+    createForIssueComment: async ({ comment_id, content }) => {
+      const fault = hit("createReaction");
+      const reaction = {
+        id: comment_id + 1000,
+        content,
+        user:
+          fault === "untrusted"
+            ? { id: 999, login: "other-bot[bot]", type: "Bot" }
+            : {
+                id: coordinator.TRUSTED_BOT_ID,
+                login: coordinator.TRUSTED_BOT_LOGIN,
+                type: "Bot",
+              },
+      };
+      (state.reactions[comment_id] ||= []).push(reaction);
+      return { data: structuredClone(reaction) };
+    },
+  };
+  return {
+    state,
+    calls,
+    faults,
+    core,
+    resetCalls() {
+      Object.keys(calls).forEach((key) => delete calls[key]);
+    },
+    addUserComment(login, body, createdAt) {
+      const comment = {
+        id: state.nextCommentId++,
+        body,
+        created_at: createdAt,
+        updated_at: createdAt,
+        user: { id: state.nextCommentId + 2000, login, type: "User" },
+      };
+      state.comments.push(comment);
+      return comment;
+    },
+    github: {
+      rest: { issues, reactions },
+      paginate: async (method, options) => (await method(options)).data,
+    },
+  };
+}
+
+function claimInput(harness) {
+  return {
+    github: harness.github,
+    core: harness.core,
+    coordinates,
+    claimant: "contributor",
+    activityAt: "2026-08-24T10:00:00.000Z",
+    triggerCommentId: 7,
+  };
+}
+
+function hasSuccess(harness) {
+  return harness.state.comments.some((comment) => /is now assigned/.test(comment.body));
+}
+
+async function expectClaimRollback(faultKey, faultValue = "throw") {
+  const harness = createHarness();
+  harness.faults[faultKey] = faultValue;
+  const result = await coordinator.claimIssue(claimInput(harness));
+  expect(result.outcome).toBe("rolled_back");
+  expect(harness.state.issue.assignees).toEqual([]);
+  expect(harness.state.issue.labels.map((label) => label.name)).toContain("status:ready");
+  expect(hasSuccess(harness)).toBe(false);
+  expect(harness.core.failures).toEqual([]);
+}
+
+async function claimedHarness() {
+  const harness = createHarness();
+  await expect(coordinator.claimIssue(claimInput(harness))).resolves.toMatchObject({
+    outcome: "claimed",
+  });
+  harness.resetCalls();
+  return harness;
+}
+
+describe("issue claim command parsing and eligibility", () => {
+  test.each([
+    ["/claim", "/claim"],
+    ["  /release\n", "/release"],
+    ["/claim extra", "invalid"],
+    ["ordinary progress", null],
+  ])("parses %p as %p", (input, expected) => {
+    expect(coordinator.parseCommand(input)).toBe(expected);
+  });
+
+  test.each([
+    ["closed issue", { state: "closed" }],
+    ["pull request", { isPullRequest: true }],
+    ["assigned issue", { assignees: ["owner"] }],
+    ["missing status", { labels: ["type:bug"] }],
+    ["duplicate status", { labels: ["type:bug", "status:ready", "status:blocked"] }],
+    ["unknown status", { labels: ["type:bug", "status:invented"] }],
+    ["non-ready status", { labels: ["type:bug", "status:needs-design"] }],
+    ["epic", { labels: ["type:epic", "status:ready"] }],
+    ["question", { labels: ["type:question", "status:ready"] }],
+    ["missing type", { labels: ["status:ready"] }],
+    ["duplicate type", { labels: ["type:bug", "type:feature", "status:ready"] }],
+    ["unknown type", { labels: ["type:invented", "status:ready"] }],
+  ])("fails closed for %s", (_name, override) => {
+    const snapshot = {
+      state: "open",
+      isPullRequest: false,
+      labels: ["type:bug", "status:ready"],
+      assignees: [],
+      ...override,
+    };
+    expect(coordinator.validateClaimable(snapshot).ok).toBe(false);
+  });
+
+  test("accepts an open, unassigned, non-epic implementation issue with one ready status", () => {
+    expect(
+      coordinator.validateClaimable({
+        state: "open",
+        isPullRequest: false,
+        labels: ["type:feature", "status:ready", "component:cli"],
+        assignees: [],
+      }),
+    ).toEqual({ ok: true });
+  });
+});
+
+describe("guarded issue ownership transitions", () => {
+  test("claims and releases with one trusted human-readable state record", async () => {
+    const harness = createHarness();
+    const claim = await coordinator.claimIssue(claimInput(harness));
+
+    expect(claim).toMatchObject({ outcome: "claimed", claimant: "contributor" });
+    expect(harness.state.issue.assignees).toEqual([{ login: "contributor" }]);
+    expect(harness.state.issue.labels.map((label) => label.name)).toEqual(
+      expect.arrayContaining(["type:bug", "component:cli", "status:in-progress"]),
+    );
+    expect(harness.state.comments).toHaveLength(1);
+    expect(harness.state.comments[0].body).toContain("2026-08-31T10:00:00.000Z");
+    expect(coordinator.parseStateComment(harness.state.comments[0]).state.status).toBe("active");
+
+    harness.resetCalls();
+    const release = await coordinator.releaseIssue({
+      github: harness.github,
+      core: harness.core,
+      coordinates,
+      claimant: "contributor",
+    });
+    expect(release.outcome).toBe("released");
+    expect(harness.state.issue.assignees).toEqual([]);
+    expect(harness.state.issue.labels.map((label) => label.name)).toContain("status:ready");
+    expect(coordinator.parseStateComment(harness.state.comments[0]).state.status).toBe("released");
+  });
+
+  test.each([
+    ["assignment API failure", "addAssignees:1", "throw"],
+    ["silently ignored assignment", "addAssignees:1", "silent"],
+    ["status-add API failure", "addLabels:1", "throw"],
+    ["silently ignored status add", "addLabels:1", "silent"],
+    ["status-remove API failure", "removeLabel:1", "throw"],
+    ["silently ignored status remove", "removeLabel:1", "silent"],
+    ["state-comment failure", "createComment:1", "throw"],
+    ["untrusted state author", "createComment:1", "untrusted"],
+    ["confirmation failure", "updateComment:1", "throw"],
+    ["silently ignored confirmation", "updateComment:1", "silent"],
+  ])("rolls back %s without publishing success", async (_name, faultKey, faultValue) => {
+    await expectClaimRollback(faultKey, faultValue);
+  });
+
+  test("preserves an unrelated label added immediately before the claim status write", async () => {
+    const harness = createHarness();
+    harness.faults["addLabels:1"] = "component-before";
+
+    const result = await coordinator.claimIssue(claimInput(harness));
+
+    expect(result.outcome).toBe("claimed");
+    expect(harness.state.issue.assignees).toEqual([{ login: "contributor" }]);
+    expect(harness.state.issue.labels.map((label) => label.name)).toContain("component:external");
+    expect(hasSuccess(harness)).toBe(true);
+  });
+
+  test("reports an unrecoverable partial transition without false success", async () => {
+    const harness = createHarness();
+    harness.faults["createComment:1"] = "throw";
+    harness.faults["addLabels:2"] = "throw";
+
+    const result = await coordinator.claimIssue(claimInput(harness));
+
+    expect(result.outcome).toBe("recovery_required");
+    expect(hasSuccess(harness)).toBe(false);
+    expect(harness.core.failures).toHaveLength(1);
+  });
+
+  test.each([
+    ["before provisional removal", "get:8", "add-maintainer"],
+    ["by replacing provisional ownership", "get:8", "replace-with-maintainer"],
+    ["between removal and label restoration", "removeAssignees:1", "add-maintainer-after"],
+  ])("preserves maintainer ownership added %s", async (_name, faultKey, faultValue) => {
+    const harness = createHarness();
+    harness.faults["updateComment:1"] = "throw";
+    harness.faults[faultKey] = faultValue;
+
+    const result = await coordinator.claimIssue(claimInput(harness));
+
+    expect(result.outcome).toBe("recovery_required");
+    expect(harness.state.issue.assignees).toEqual([{ login: "maintainer-choice" }]);
+    expect(harness.state.issue.labels.map((label) => label.name)).toContain("status:in-progress");
+    expect(harness.state.issue.labels.map((label) => label.name)).not.toContain("status:ready");
+    expect(hasSuccess(harness)).toBe(false);
+  });
+
+  test.each([
+    ["lease record", "updateComment:1"],
+    ["ready status add", "addLabels:1"],
+    ["in-progress status removal", "removeLabel:1"],
+    ["assignee removal", "removeAssignees:1"],
+    ["released record", "updateComment:2"],
+  ])("rolls back a failed release at the %s boundary", async (_name, faultKey) => {
+    const harness = await claimedHarness();
+    harness.faults[faultKey] = "throw";
+
+    const result = await coordinator.releaseIssue({
+      github: harness.github,
+      core: harness.core,
+      coordinates,
+      claimant: "contributor",
+    });
+
+    expect(result.outcome).toBe("rolled_back");
+    expect(harness.state.issue.assignees).toEqual([{ login: "contributor" }]);
+    expect(harness.state.issue.labels.map((label) => label.name)).toContain("status:in-progress");
+    expect(coordinator.parseStateComment(harness.state.comments[0]).state.status).toBe("active");
+    expect(harness.core.failures).toEqual([]);
+  });
+
+  test.each([
+    [
+      "claim",
+      async () => {
+        const harness = createHarness();
+        harness.faults["addLabels:1"] = "status-blocked-before";
+        return { harness, result: await coordinator.claimIssue(claimInput(harness)) };
+      },
+    ],
+    [
+      "release",
+      async () => {
+        const harness = await claimedHarness();
+        harness.faults["addLabels:1"] = "status-blocked-before";
+        const result = await coordinator.releaseIssue({
+          github: harness.github,
+          core: harness.core,
+          coordinates,
+          claimant: "contributor",
+        });
+        return { harness, result };
+      },
+    ],
+    [
+      "rollback",
+      async () => {
+        const harness = createHarness();
+        harness.faults["updateComment:1"] = "throw";
+        harness.faults["addLabels:2"] = "status-blocked-before";
+        return { harness, result: await coordinator.claimIssue(claimInput(harness)) };
+      },
+    ],
+  ])("preserves a competing status immediately before the %s status write", async (_name, run) => {
+    const { harness, result } = await run();
+    expect(result.outcome).toBe("recovery_required");
+    expect(harness.state.issue.labels.map((label) => label.name)).toContain("status:blocked");
+    expect(harness.state.issue.labels.map((label) => label.name)).not.toContain("status:ready");
+  });
+
+  test("preserves unrelated labels during release and rollback status writes", async () => {
+    const released = await claimedHarness();
+    released.faults["addLabels:1"] = "component-before";
+    await expect(
+      coordinator.releaseIssue({
+        github: released.github,
+        core: released.core,
+        coordinates,
+        claimant: "contributor",
+      }),
+    ).resolves.toMatchObject({ outcome: "released" });
+    expect(released.state.issue.labels.map((label) => label.name)).toContain("component:external");
+
+    const rolledBack = createHarness();
+    rolledBack.faults["updateComment:1"] = "throw";
+    rolledBack.faults["addLabels:2"] = "component-before";
+    await expect(coordinator.claimIssue(claimInput(rolledBack))).resolves.toMatchObject({
+      outcome: "rolled_back",
+    });
+    expect(rolledBack.state.issue.labels.map((label) => label.name)).toContain(
+      "component:external",
+    );
+  });
+
+  test("allows only the current sole assignee to release", async () => {
+    const harness = await claimedHarness();
+    const result = await coordinator.releaseIssue({
+      github: harness.github,
+      core: harness.core,
+      coordinates,
+      claimant: "someone-else",
+    });
+    expect(result.outcome).toBe("rejected");
+    expect(harness.state.issue.assignees).toEqual([{ login: "contributor" }]);
+  });
+
+  test("drains competing commands in creation order and marks each exactly once", async () => {
+    const harness = createHarness();
+    const first = harness.addUserComment("first-contributor", "/claim", "2026-08-24T10:00:00Z");
+    const second = harness.addUserComment("second-contributor", "/claim", "2026-08-24T10:00:01Z");
+    const context = { repo: { owner: "moira-mcp", repo: "moira" }, payload: {} };
+
+    const outcomes = await coordinator.drainIssueCommands({
+      github: harness.github,
+      context,
+      core: harness.core,
+      coordinates,
+    });
+
+    expect(outcomes.map((outcome) => outcome.result.outcome)).toEqual(["claimed", "rejected"]);
+    expect(harness.state.issue.assignees).toEqual([{ login: "first-contributor" }]);
+    expect(harness.state.reactions[first.id]).toHaveLength(1);
+    expect(harness.state.reactions[second.id]).toHaveLength(1);
+    await expect(
+      coordinator.drainIssueCommands({
+        github: harness.github,
+        context,
+        core: harness.core,
+        coordinates,
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  test("a later progress-event run drains an earlier pending release", async () => {
+    const harness = await claimedHarness();
+    harness.addUserComment("contributor", "/release", "2026-08-25T10:00:00Z");
+    const progress = harness.addUserComment(
+      "contributor",
+      "Progress after the queued command",
+      "2026-08-25T10:00:01Z",
+    );
+
+    const result = await coordinator.handleIssueEvent({
+      github: harness.github,
+      core: harness.core,
+      context: {
+        repo: { owner: "moira-mcp", repo: "moira" },
+        payload: { issue: { number: 42 }, comment: progress },
+      },
+    });
+
+    expect(result.commands.map((command) => command.result.outcome)).toEqual(["released"]);
+    expect(result.renewal.outcome).toBe("ignored");
+    expect(harness.state.issue.assignees).toEqual([]);
+    expect(harness.state.issue.labels.map((label) => label.name)).toContain("status:ready");
+  });
+
+  test("retries a rolled-back command when its required response was not published", async () => {
+    const harness = createHarness();
+    const command = harness.addUserComment("contributor", "/claim", "2026-08-24T10:00:00Z");
+    const context = { repo: { owner: "moira-mcp", repo: "moira" }, payload: {} };
+    harness.faults["updateComment:1"] = "throw";
+    harness.faults["createComment:2"] = "throw";
+
+    await expect(
+      coordinator.drainIssueCommands({
+        github: harness.github,
+        context,
+        core: harness.core,
+        coordinates,
+      }),
+    ).rejects.toThrow("injected createComment:2");
+    expect(harness.state.issue.assignees).toEqual([]);
+    expect(harness.state.issue.labels.map((label) => label.name)).toContain("status:ready");
+    expect(coordinator.parseStateComment(harness.state.comments[1]).state.status).toBe("aborted");
+    expect(harness.state.reactions[command.id]).toBeUndefined();
+
+    harness.resetCalls();
+    delete harness.faults["updateComment:1"];
+    delete harness.faults["createComment:2"];
+    const replay = await coordinator.drainIssueCommands({
+      github: harness.github,
+      context,
+      core: harness.core,
+      coordinates,
+    });
+    expect(replay.map((outcome) => outcome.result.outcome)).toEqual(["claimed"]);
+    expect(harness.state.issue.assignees).toEqual([{ login: "contributor" }]);
+    expect(harness.state.reactions[command.id]).toHaveLength(1);
+    expect(
+      harness.state.comments.filter((comment) =>
+        Boolean(coordinator.parseStateComment(comment)?.state),
+      ),
+    ).toHaveLength(1);
+  });
+
+  test.each(["throw", "untrusted"])(
+    "replays safely when the processed reaction initially %s",
+    async (fault) => {
+      const harness = createHarness();
+      const command = harness.addUserComment("contributor", "/claim", "2026-08-24T10:00:00Z");
+      const context = { repo: { owner: "moira-mcp", repo: "moira" }, payload: {} };
+      harness.faults["createReaction:1"] = fault;
+
+      await expect(
+        coordinator.drainIssueCommands({
+          github: harness.github,
+          context,
+          core: harness.core,
+          coordinates,
+        }),
+      ).rejects.toThrow();
+      expect(harness.state.issue.assignees).toEqual([{ login: "contributor" }]);
+      await expect(
+        coordinator.commandWasProcessed(harness.github, coordinates, command.id),
+      ).resolves.toBe(false);
+
+      harness.resetCalls();
+      delete harness.faults["createReaction:1"];
+      const replay = await coordinator.drainIssueCommands({
+        github: harness.github,
+        context,
+        core: harness.core,
+        coordinates,
+      });
+      expect(replay.map((outcome) => outcome.result.outcome)).toEqual([
+        "processed_marker_recovered",
+      ]);
+      expect(harness.state.issue.assignees).toEqual([{ login: "contributor" }]);
+      await expect(
+        coordinator.commandWasProcessed(harness.github, coordinates, command.id),
+      ).resolves.toBe(true);
+    },
+  );
+
+  test("recovers a missing processed reaction after an already applied release", async () => {
+    const harness = await claimedHarness();
+    const command = harness.addUserComment("contributor", "/release", "2026-08-25T10:00:00Z");
+    const context = { repo: { owner: "moira-mcp", repo: "moira" }, payload: {} };
+    harness.faults["createReaction:1"] = "throw";
+
+    await expect(
+      coordinator.drainIssueCommands({
+        github: harness.github,
+        context,
+        core: harness.core,
+        coordinates,
+      }),
+    ).rejects.toThrow();
+    expect(harness.state.issue.assignees).toEqual([]);
+    expect(coordinator.parseStateComment(harness.state.comments[0]).state).toMatchObject({
+      status: "released",
+      lastCompletedCommandId: command.id,
+    });
+
+    harness.resetCalls();
+    delete harness.faults["createReaction:1"];
+    const replay = await coordinator.drainIssueCommands({
+      github: harness.github,
+      context,
+      core: harness.core,
+      coordinates,
+    });
+    expect(replay.map((outcome) => outcome.result.outcome)).toEqual(["processed_marker_recovered"]);
+    await expect(
+      coordinator.commandWasProcessed(harness.github, coordinates, command.id),
+    ).resolves.toBe(true);
+  });
+
+  test.each([
+    [
+      "claim rejection",
+      () => {
+        const harness = createHarness();
+        harness.state.issue.labels = [{ name: "type:bug" }, { name: "status:needs-design" }];
+        const comment = harness.addUserComment("contributor", "/claim", "2026-08-24T10:00:00Z");
+        return { harness, comment };
+      },
+    ],
+    [
+      "release rejection",
+      async () => {
+        const harness = await claimedHarness();
+        const comment = harness.addUserComment("someone-else", "/release", "2026-08-25T10:00:00Z");
+        return { harness, comment };
+      },
+    ],
+  ])("replays %s when the required explanation initially fails", async (_name, setup) => {
+    const prepared = await setup();
+    const { harness, comment } = prepared;
+    const context = { repo: { owner: "moira-mcp", repo: "moira" }, payload: {} };
+    harness.faults["createComment:1"] = "throw";
+
+    await expect(
+      coordinator.drainIssueCommands({
+        github: harness.github,
+        context,
+        core: harness.core,
+        coordinates,
+      }),
+    ).rejects.toThrow("injected createComment:1");
+    expect(harness.state.reactions[comment.id]).toBeUndefined();
+
+    harness.resetCalls();
+    delete harness.faults["createComment:1"];
+    const replay = await coordinator.drainIssueCommands({
+      github: harness.github,
+      context,
+      core: harness.core,
+      coordinates,
+    });
+    expect(replay.map((outcome) => outcome.result.outcome)).toEqual(["rejected"]);
+    expect(harness.state.reactions[comment.id]).toHaveLength(1);
+  });
+});

--- a/tests/unit/github/issue-claim-workflow-contract.test.cjs
+++ b/tests/unit/github/issue-claim-workflow-contract.test.cjs
@@ -1,0 +1,76 @@
+"use strict";
+
+const { readFileSync } = require("node:fs");
+const { resolve } = require("node:path");
+const { describe, expect, test } = require("@jest/globals");
+const coordinator = require("../../../.github/scripts/issue-claim.cjs");
+
+describe("issue claim GitHub Actions contract", () => {
+  const workflow = readFileSync(resolve(".github/workflows/issue-claims.yml"), "utf8");
+  const contributing = readFileSync(resolve("CONTRIBUTING.md"), "utf8");
+  const agents = readFileSync(resolve("AGENTS.md"), "utf8");
+  const triage = readFileSync(resolve(".github/ISSUE_TRIAGE.md"), "utf8");
+  const bugTemplate = readFileSync(resolve(".github/ISSUE_TEMPLATE/bug_report.md"), "utf8");
+  const featureTemplate = readFileSync(
+    resolve(".github/ISSUE_TEMPLATE/feature_request.md"),
+    "utf8",
+  );
+
+  test("uses trusted default-branch code, least privilege and no contributor-code trigger", () => {
+    expect(workflow).toContain("permissions: {}");
+    expect(workflow).toContain("ref: ${{ github.event.repository.default_branch }}");
+    expect(workflow).toContain("persist-credentials: false");
+    expect(
+      workflow.match(/actions\/checkout@11d5960a326750d5838078e36cf38b85af677262/g),
+    ).toHaveLength(3);
+    expect(
+      workflow.match(/actions\/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b/g),
+    ).toHaveLength(3);
+    expect(workflow).not.toMatch(/uses: actions\/(checkout|github-script)@v\d/);
+    expect(workflow).toContain("contents: read");
+    expect(workflow).toContain("issues: write");
+    expect(workflow).toContain("pull-requests: read");
+    expect(workflow).not.toContain("pull_request_target");
+  });
+
+  test("serializes commands and scheduled reconciliation with the same per-issue key", () => {
+    expect(workflow.match(/group: issue-claim-\$\{\{ github\.repository \}\}-/g)).toHaveLength(2);
+    expect(workflow).toContain("github.event.issue.number");
+    expect(workflow).toContain("matrix.issue_number");
+    expect(workflow.match(/cancel-in-progress: false/g)).toHaveLength(2);
+  });
+
+  test("provides command, daily, manual-target and per-issue reconciliation paths", () => {
+    expect(workflow).toContain("issue_comment:");
+    expect(workflow).toContain("schedule:");
+    expect(workflow).toContain("workflow_dispatch:");
+    expect(workflow).toContain("issue_number:");
+    expect(workflow).toContain("fromJSON(needs.lease_discovery.outputs.issue_numbers)");
+    expect(workflow).toContain("coordinator.handleIssueEvent");
+    expect(workflow).toContain("coordinator.drainIssueCommands");
+    expect(workflow).toContain("coordinator.reconcileIssue");
+  });
+
+  test("keeps contributor, maintainer, agent and issue-template contracts aligned", () => {
+    for (const value of [
+      coordinator.CLAIM_COMMAND,
+      coordinator.RELEASE_COMMAND,
+      coordinator.READY_STATUS,
+      coordinator.IN_PROGRESS_STATUS,
+      coordinator.STATE_MARKER,
+      coordinator.REMINDER_MARKER,
+    ]) {
+      expect(contributing).toContain(value);
+    }
+    expect(contributing).toContain("seven days");
+    expect(contributing).toContain("three-day grace period");
+    expect(contributing).toContain("closing keyword");
+    expect(contributing).toContain("first successful reconciliation");
+    expect(agents).toContain("read `CONTRIBUTING.md` completely");
+    expect(triage).toContain("assignee");
+    expect(triage).toContain("`/claim`");
+    expect(triage).toContain("`/release`");
+    expect(bugTemplate).toContain('labels: "type:bug, status:needs-triage"');
+    expect(featureTemplate).toContain('labels: "type:feature, status:needs-triage"');
+  });
+});


### PR DESCRIPTION
## Summary

- add guarded /claim and /release coordination for external contributors
- add bounded activity leases with reminders, safe replay, and scheduled reconciliation
- document contributor, maintainer, triage, and agent contracts
- update issue templates to the current label taxonomy

## Safety

- default-branch trusted code only; Actions pinned by full SHA
- least-privilege job permissions and per-issue concurrency
- coalescing-safe command drain with trusted bot reactions
- label-specific status transitions preserve unrelated and maintainer labels
- partial mutations, replies, reminders, and processed markers are replay/recovery safe

## Testing

- transition suite: 51/51 passed
- lease suite: 18/18 passed
- workflow/docs contract: 4/4 passed
- full unit suite: 1614/1614 passed under Node 22
- full Prettier check passed
- full ESLint check passed with one unrelated existing React hooks warning
- independent final review: zero blocking and zero non-blocking findings

## Checklist

- [x] DCO signed-off commit
- [x] Documentation updated
- [x] No secrets or personal paths
- [x] No deployment required