### PR TITLE
ci(github): enforce release and PR policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Repository governance and supply-chain boundaries
+/.github/workflows/ @witqq
+/.github/scripts/ @witqq
+/.github/CODEOWNERS @witqq
+/.github/dependabot.yml @witqq
+/.releaserc.json @witqq
+/SECURITY.md @witqq
+/config/Dockerfile @witqq
+/config/.dockerignore @witqq
+/config/docker-entrypoint.sh @witqq
+/docker-compose*.yml @witqq
+/package.json @witqq
+/package-lock.json @witqq
+/packages/*/package.json @witqq
+/packages/*/package-lock.json @witqq

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,11 @@ Briefly describe what this PR does and why.
 
 ## Related issues
 
+<!-- Use a GitHub closing keyword for an issue in this repository: Closes #123. -->
+
 Closes #
+
+<!-- Maintainers may replace the line above with `No issue: concrete reason` only for github, repo, or contributing scopes. -->
 
 ## Changes
 
@@ -13,14 +17,15 @@ Closes #
 
 ## Testing
 
-How did you verify the change? (commands run, tests added, manual steps)
+<!-- Keep one or more Command/Manual lines and an explicit observed Outcome. -->
 
-- [ ] Tests pass locally
-- [ ] Added/updated tests for the change
-- [ ] Updated documentation if behavior changed
+- Command: <command run>
+- Outcome: <observed outcome>
 
 ## Checklist
 
 - [ ] My commits are signed off (DCO): `git commit -s` (see CONTRIBUTING.md)
+- [ ] Added or updated tests for behavior changes
+- [ ] Updated documentation for user-facing behavior changes
 - [ ] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md)
 - [ ] No secrets, credentials, or personal paths are included

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,7 @@ Closes #
 
 ## Checklist
 
-- [ ] My commits are signed off (DCO): `git commit -s` (see CONTRIBUTING.md)
+- [ ] Every commit has a DCO `Signed-off-by` matching its Git author name/email (see CONTRIBUTING.md)
 - [ ] Added or updated tests for behavior changes
 - [ ] Updated documentation for user-facing behavior changes
 - [ ] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md)

--- a/.github/scripts/pr-policy-adapter.cjs
+++ b/.github/scripts/pr-policy-adapter.cjs
@@ -1,0 +1,155 @@
+"use strict";
+
+const policy = require("./pr-policy.cjs");
+
+const PAGE_SIZE = 100;
+const MAX_REFERENCE_PAGES = 10;
+
+async function listCommits(github, coordinates, expectedCount) {
+  if (expectedCount > policy.MAX_COMMITS) return { commits: [], overflow: true };
+  const commits = [];
+  for (let page = 1; page <= Math.ceil(policy.MAX_COMMITS / PAGE_SIZE); page += 1) {
+    const response = await github.rest.pulls.listCommits({
+      ...coordinates,
+      per_page: PAGE_SIZE,
+      page,
+    });
+    const rows = response.data || [];
+    commits.push(...rows);
+    if (commits.length > policy.MAX_COMMITS) {
+      return { commits: commits.slice(0, policy.MAX_COMMITS), overflow: true };
+    }
+    if (rows.length < PAGE_SIZE) {
+      if (Number.isInteger(expectedCount) && commits.length !== expectedCount) {
+        throw new Error("pull-request commit count changed during collection");
+      }
+      return { commits, overflow: false };
+    }
+  }
+  if (Number.isInteger(expectedCount) && commits.length !== expectedCount) {
+    throw new Error("pull-request commit count changed during collection");
+  }
+  return { commits, overflow: false };
+}
+
+async function listClosingIssues(github, coordinates) {
+  const query = `
+    query PullRequestClosingIssues($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) {
+          closingIssuesReferences(first: 100, after: $cursor) {
+            nodes { number repository { nameWithOwner } }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+      }
+    }
+  `;
+  const issues = [];
+  let cursor = null;
+  for (let page = 0; page < MAX_REFERENCE_PAGES; page += 1) {
+    const result = await github.graphql(query, { ...coordinates, cursor });
+    const references = result.repository?.pullRequest?.closingIssuesReferences;
+    if (!references) throw new Error("GitHub did not return pull-request closing references");
+    issues.push(...(references.nodes || []));
+    if (!references.pageInfo?.hasNextPage) return { issues, overflow: false };
+    cursor = references.pageInfo.endCursor;
+    if (!cursor) throw new Error("GitHub returned an invalid closing-reference cursor");
+  }
+  return { issues, overflow: true };
+}
+
+async function getPermission(github, coordinates, username) {
+  try {
+    const response = await github.rest.repos.getCollaboratorPermissionLevel({
+      owner: coordinates.owner,
+      repo: coordinates.repo,
+      username,
+    });
+    const roleName = response.data?.role_name;
+    if (roleName === "admin" || roleName === "maintain" || roleName === "write") return roleName;
+    return response.data?.permission || null;
+  } catch (error) {
+    if (error?.status === 404) return null;
+    throw error;
+  }
+}
+
+function commitFact(commit) {
+  const message = commit.commit?.message;
+  const author = commit.commit?.author;
+  const messageOverflow =
+    typeof message === "string" && message.length > policy.MAX_COMMIT_MESSAGE_LENGTH;
+  const gitAuthorOverflow =
+    (typeof author?.name === "string" && author.name.length > policy.MAX_GIT_IDENTITY_LENGTH) ||
+    (typeof author?.email === "string" && author.email.length > policy.MAX_GIT_IDENTITY_LENGTH);
+  return {
+    sha: commit.sha,
+    message: messageOverflow ? null : message,
+    messageOverflow,
+    gitAuthor: gitAuthorOverflow ? null : author,
+    gitAuthorOverflow,
+    githubAuthor: commit.author,
+    verified: commit.commit?.verification?.verified === true,
+  };
+}
+
+async function collectFacts({ github, context }) {
+  const pull = context.payload.pull_request;
+  if (!pull) throw new Error("pull_request payload is required");
+  const coordinates = {
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: pull.number,
+  };
+  const [commitResult, closingResult, authorPermission] = await Promise.all([
+    listCommits(github, coordinates, pull.commits),
+    listClosingIssues(github, {
+      owner: coordinates.owner,
+      repo: coordinates.repo,
+      number: pull.number,
+    }),
+    policy.isExactDependabotUser(pull.user)
+      ? Promise.resolve(null)
+      : getPermission(
+          github,
+          { owner: coordinates.owner, repo: coordinates.repo },
+          pull.user.login,
+        ),
+  ]);
+  const body = pull.body || "";
+  const bodyOverflow = body.length > policy.MAX_BODY_LENGTH;
+  return {
+    repository: { owner: coordinates.owner, repo: coordinates.repo },
+    title: pull.title,
+    body: bodyOverflow ? "" : body,
+    bodyOverflow,
+    author: { login: pull.user.login, id: pull.user.id, type: pull.user.type },
+    authorPermission,
+    commits: commitResult.commits.map(commitFact),
+    commitsOverflow: commitResult.overflow,
+    closingIssues: closingResult.issues,
+    closingIssuesOverflow: closingResult.overflow,
+  };
+}
+
+async function run({ github, context, core }) {
+  const result = policy.validatePullRequest(await collectFacts({ github, context }));
+  if (!result.ok) {
+    core.setFailed(
+      ["Pull-request policy failed:", ...result.findings.map((item) => `- ${item.message}`)].join(
+        "\n",
+      ),
+    );
+  }
+  return result;
+}
+
+module.exports = {
+  collectFacts,
+  commitFact,
+  getPermission,
+  listClosingIssues,
+  listCommits,
+  run,
+};

--- a/.github/scripts/pr-policy.cjs
+++ b/.github/scripts/pr-policy.cjs
@@ -1,0 +1,265 @@
+"use strict";
+
+const ALLOWED_TYPES = new Set([
+  "build",
+  "chore",
+  "ci",
+  "docs",
+  "feat",
+  "fix",
+  "perf",
+  "refactor",
+  "revert",
+  "style",
+  "test",
+]);
+const NO_ISSUE_SCOPES = new Set(["github", "repo", "contributing"]);
+const NO_ISSUE_PERMISSIONS = new Set(["write", "maintain", "admin"]);
+const PLACEHOLDERS = new Set([
+  "...",
+  "area",
+  "brief description",
+  "component",
+  "description",
+  "n/a",
+  "none",
+  "reason",
+  "scope",
+  "subject",
+  "tbd",
+  "todo",
+]);
+const MAX_TITLE_LENGTH = 160;
+const MAX_BODY_LENGTH = 65536;
+const MAX_COMMITS = 250;
+const MAX_COMMIT_MESSAGE_LENGTH = 65536;
+const MAX_GIT_IDENTITY_LENGTH = 512;
+const DEPENDABOT = Object.freeze({ login: "dependabot[bot]", id: 49699333, type: "Bot" });
+
+function finding(code, message) {
+  return { code, message };
+}
+
+function concrete(value) {
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
+  return normalized.length >= 2 && !PLACEHOLDERS.has(normalized) && !/^<.*>$/.test(normalized);
+}
+
+function nonEmpty(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function parseTitle(title) {
+  if (typeof title !== "string" || title.length === 0 || title.length > MAX_TITLE_LENGTH) {
+    return { ok: false, reason: `title must contain 1-${MAX_TITLE_LENGTH} characters` };
+  }
+  const match = title.match(/^([a-z]+)\(([a-z0-9]+(?:-[a-z0-9]+)*)\)(!)?: (.+)$/);
+  if (!match) {
+    return { ok: false, reason: "title must match type(scope)[!]: subject" };
+  }
+  const [, type, scope, bang, subject] = match;
+  if (!ALLOWED_TYPES.has(type)) {
+    return { ok: false, reason: `title type ${JSON.stringify(type)} is not allowed` };
+  }
+  if (!concrete(scope)) return { ok: false, reason: "title scope is a placeholder" };
+  if (!concrete(subject)) return { ok: false, reason: "title subject is a placeholder" };
+  return { ok: true, type, scope, breaking: Boolean(bang), subject };
+}
+
+function section(body, heading) {
+  const lines = body.split(/\r?\n/);
+  const start = lines.findIndex(
+    (line) => line.trim().toLowerCase() === `## ${heading}`.toLowerCase(),
+  );
+  if (start < 0) return null;
+  const endOffset = lines.slice(start + 1).findIndex((line) => /^##\s+/.test(line.trim()));
+  const end = endOffset < 0 ? lines.length : start + 1 + endOffset;
+  return lines
+    .slice(start + 1, end)
+    .join("\n")
+    .trim();
+}
+
+function fieldValue(content, names) {
+  const alternatives = names.join("|");
+  const match = content.match(new RegExp(`^-\\s*(?:${alternatives}):\\s*(.+)$`, "im"));
+  return match?.[1]?.trim() || null;
+}
+
+function validateTesting(body) {
+  const testing = section(body, "Testing");
+  if (testing === null) return "body must contain a ## Testing section";
+  const verification = fieldValue(testing, ["Command", "Manual"]);
+  const outcome = fieldValue(testing, ["Outcome"]);
+  if (!concrete(verification)) {
+    return "Testing must name a concrete Command or Manual observation";
+  }
+  if (!concrete(outcome)) return "Testing must state a concrete Outcome";
+  return null;
+}
+
+function noIssueReason(body) {
+  const matches = [...body.matchAll(/^No issue:\s*(.*)$/gim)];
+  if (matches.length !== 1 || !concrete(matches[0][1])) return null;
+  return matches[0][1].trim();
+}
+
+function sameRepositoryClosingIssue(closingIssues, repository) {
+  const expected = `${repository.owner}/${repository.repo}`.toLowerCase();
+  return closingIssues.some(
+    (issue) => issue?.repository?.nameWithOwner?.toLowerCase() === expected,
+  );
+}
+
+function dcoMatches(commit) {
+  const author = commit?.gitAuthor;
+  if (!nonEmpty(author?.name) || !nonEmpty(author?.email) || typeof commit?.message !== "string") {
+    return false;
+  }
+  const trailers = [...commit.message.matchAll(/^Signed-off-by:\s*(.+?)\s*<([^<>\s]+)>\s*$/gim)];
+  return trailers.some(
+    ([, name, email]) =>
+      name.trim() === author.name.trim() && email.toLowerCase() === author.email.toLowerCase(),
+  );
+}
+
+function commitTextFindings(commit) {
+  const findings = [];
+  const shortSha = typeof commit?.sha === "string" ? commit.sha.slice(0, 12) : "unknown";
+  if (
+    commit?.messageOverflow ||
+    (typeof commit?.message === "string" && commit.message.length > MAX_COMMIT_MESSAGE_LENGTH)
+  ) {
+    findings.push(
+      finding(
+        "commit-message-too-large",
+        `commit ${shortSha} message exceeds ${MAX_COMMIT_MESSAGE_LENGTH} characters`,
+      ),
+    );
+  }
+  if (
+    commit?.gitAuthorOverflow ||
+    (typeof commit?.gitAuthor?.name === "string" &&
+      commit.gitAuthor.name.length > MAX_GIT_IDENTITY_LENGTH) ||
+    (typeof commit?.gitAuthor?.email === "string" &&
+      commit.gitAuthor.email.length > MAX_GIT_IDENTITY_LENGTH)
+  ) {
+    findings.push(
+      finding(
+        "commit-identity-too-large",
+        `commit ${shortSha} Git author identity exceeds ${MAX_GIT_IDENTITY_LENGTH} characters`,
+      ),
+    );
+  }
+  return findings;
+}
+
+function exactUser(actual, expected) {
+  return (
+    actual?.login === expected.login && actual?.id === expected.id && actual?.type === expected.type
+  );
+}
+
+function isExactDependabotUser(user) {
+  return exactUser(user, DEPENDABOT);
+}
+
+function isExactDependabot(input, title) {
+  return (
+    isExactDependabotUser(input.author) &&
+    title.ok &&
+    title.type === "build" &&
+    !title.breaking &&
+    (title.scope === "deps" || title.scope === "deps-dev") &&
+    input.commits.length > 0 &&
+    input.commits.every(
+      (commit) => commit?.verified === true && isExactDependabotUser(commit?.githubAuthor),
+    )
+  );
+}
+
+function validatePullRequest(input) {
+  const findings = [];
+  const title = parseTitle(input?.title);
+  if (!title.ok) findings.push(finding("title", title.reason));
+
+  const body = typeof input?.body === "string" ? input.body : "";
+  if (input?.bodyOverflow || body.length > MAX_BODY_LENGTH) {
+    findings.push(finding("body-too-large", `body exceeds ${MAX_BODY_LENGTH} characters`));
+  }
+  const commits = Array.isArray(input?.commits) ? input.commits : [];
+  if (input?.commitsOverflow || commits.length > MAX_COMMITS) {
+    findings.push(finding("commits-too-many", `pull request exceeds ${MAX_COMMITS} commits`));
+  }
+  if (input?.closingIssuesOverflow) {
+    findings.push(
+      finding("closing-issues-too-many", "closing issue references exceed the supported bound"),
+    );
+  }
+  const commitTextFindingsByIndex = commits
+    .slice(0, MAX_COMMITS)
+    .map((commit) => commitTextFindings(commit));
+  findings.push(...commitTextFindingsByIndex.flat());
+
+  if (isExactDependabot({ ...input, commits }, title)) {
+    return { ok: findings.length === 0, findings };
+  }
+
+  const boundedBody = !input?.bodyOverflow && body.length <= MAX_BODY_LENGTH ? body : "";
+  const testingProblem = validateTesting(boundedBody);
+  if (testingProblem) findings.push(finding("testing", testingProblem));
+
+  const repository = input?.repository || {};
+  const closingIssues = Array.isArray(input?.closingIssues) ? input.closingIssues : [];
+  const hasClosingIssue = sameRepositoryClosingIssue(closingIssues, repository);
+  if (!hasClosingIssue) {
+    const reason = noIssueReason(boundedBody);
+    const noIssueAllowed =
+      reason &&
+      title.ok &&
+      NO_ISSUE_SCOPES.has(title.scope) &&
+      NO_ISSUE_PERMISSIONS.has(input?.authorPermission);
+    if (!noIssueAllowed) {
+      findings.push(
+        finding(
+          "issue-linkage",
+          "add a same-repository closing issue, or use an authorized repository-scope No issue: reason",
+        ),
+      );
+    }
+  }
+
+  if (commits.length === 0) {
+    findings.push(finding("commits", "pull request contains no inspectable commits"));
+  } else {
+    for (const [index, commit] of commits.slice(0, MAX_COMMITS).entries()) {
+      const textFindings = commitTextFindingsByIndex[index];
+      if (textFindings.length === 0 && !dcoMatches(commit)) {
+        const shortSha = typeof commit?.sha === "string" ? commit.sha.slice(0, 12) : "unknown";
+        findings.push(
+          finding("dco", `commit ${shortSha} lacks a Signed-off-by matching its Git author`),
+        );
+      }
+    }
+  }
+
+  return { ok: findings.length === 0, findings };
+}
+
+module.exports = {
+  ALLOWED_TYPES,
+  DEPENDABOT,
+  MAX_BODY_LENGTH,
+  MAX_COMMIT_MESSAGE_LENGTH,
+  MAX_COMMITS,
+  MAX_GIT_IDENTITY_LENGTH,
+  MAX_TITLE_LENGTH,
+  NO_ISSUE_PERMISSIONS,
+  NO_ISSUE_SCOPES,
+  dcoMatches,
+  commitTextFindings,
+  isExactDependabotUser,
+  parseTitle,
+  validatePullRequest,
+  validateTesting,
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Run unit tests
         run: npm run test:unit
 
+      - name: Verify release policy
+        run: npm run test:release-policy
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -1,0 +1,30 @@
+name: PR Policy
+
+on:
+  pull_request:
+    branches: [master]
+    types: [opened, edited, reopened, synchronize]
+
+permissions: {}
+
+jobs:
+  policy:
+    name: PR Policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Check out trusted default-branch policy
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Validate pull request
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const adapter = require('./.github/scripts/pr-policy-adapter.cjs');
+            await adapter.run({ github, context, core });

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -1,7 +1,7 @@
 name: PR Policy
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [master]
     types: [opened, edited, reopened, synchronize]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,12 @@ jobs:
       - name: semantic-release
         id: semantic
         uses: cycjimmy/semantic-release-action@v6
+        with:
+          semantic_version: 24.2.9
+          extra_plugins: |
+            @semantic-release/commit-analyzer@13.0.1
+            @semantic-release/release-notes-generator@14.1.1
+            conventional-changelog-conventionalcommits@9.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,8 +1,39 @@
 {
   "branches": ["master"],
   "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          { "scope": "github", "release": false },
+          { "scope": "repo", "release": false },
+          { "scope": "contributing", "release": false }
+        ],
+        "parserOpts": {
+          "noteKeywords": [
+            "BREAKING CHANGE",
+            "BREAKING CHANGES",
+            "BREAKING-CHANGE",
+            "BREAKING-CHANGES"
+          ]
+        }
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "parserOpts": {
+          "noteKeywords": [
+            "BREAKING CHANGE",
+            "BREAKING CHANGES",
+            "BREAKING-CHANGE",
+            "BREAKING-CHANGES"
+          ]
+        }
+      }
+    ],
     [
       "@semantic-release/github",
       {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,8 +146,72 @@ lifecycle state but must not be used by itself to reserve work.
 4. Add or update tests for any behavior change.
 5. Run the test suite and make sure it passes.
 6. Update documentation if you changed user-facing behavior.
-7. Open a pull request against `master`, use a closing reference to the claimed
-   issue, and describe what and why.
+7. Open a pull request against `master`, follow the policy below, use a closing
+   reference to the claimed issue, and describe what and why.
+
+## Pull-request policy
+
+Every pull request to `master` is checked by **PR Policy**. The check reports all
+current findings together and runs again when the pull request is opened, edited,
+reopened, or receives new commits.
+
+Use this title form:
+
+```text
+type(scope)[!]: subject
+```
+
+Allowed types are `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`,
+`refactor`, `revert`, `style`, and `test`. The scope is required, lowercase, and
+uses letters, digits, and internal hyphens. Replace `scope` and `subject` with
+specific values. The optional `!` marks a breaking product change. Keep the title
+within 160 characters. This form also keeps the title valid when it is used as a
+squash commit subject.
+
+### Link the work to an issue
+
+Outside contributors must make GitHub recognize a closing reference to an issue in
+this repository. Put a closing keyword in the pull-request body, for example:
+
+```text
+Closes #123
+```
+
+A plain issue mention does not count. Maintainers with effective `write`,
+`maintain`, or `admin` permission may omit an issue only for repository
+housekeeping whose title scope is `github`, `repo`, or `contributing`. Replace the
+closing line with one concrete reason:
+
+```text
+No issue: refresh repository policy metadata
+```
+
+Author association labels such as MEMBER or COLLABORATOR do not grant this
+exception, and product scopes cannot use it.
+
+### Record testing evidence
+
+Keep the `## Testing` section and record at least one concrete command or named
+manual observation plus its observed outcome:
+
+```markdown
+## Testing
+
+- Command: `npm run test:unit -- --file tests/unit/example.test.ts`
+- Outcome: tests passed
+```
+
+For a manual check, use `- Manual: <observation>` instead of `- Command:`. The
+policy verifies that both the verification and outcome are present; reviewers
+still judge whether the evidence is adequate for the change.
+
+### Automated dependency pull requests
+
+Dependabot may omit the human issue, Testing, and DCO fields only when GitHub
+identifies the pull request and every verified commit as the official
+`dependabot[bot]` account and the title uses `build(deps): …` or
+`build(deps-dev): …`. Other bots and partial identity matches follow the human
+requirements.
 
 ## Sign your commits (DCO)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,6 +224,13 @@ git commit -s -m "your message"
 ```
 
 This adds a `Signed-off-by: Your Name <your@email>` line to the commit message.
+**PR Policy** requires at least one such trailer whose name exactly matches that
+commit's Git author name and whose email matches the Git author email
+case-insensitively. `git commit -s` is the ordinary path when your configured Git
+identity is also the commit author. For an amended, rewritten, or cherry-picked
+commit, inspect its Git author and ensure the matching author trailer is already
+present. Change the author only when that authorship remains accurate; otherwise
+obtain the author's sign-off or omit the commit.
 
 ## Releases & versioning
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,8 +171,14 @@ commit subjects accordingly:
 | -------------------------------------------------- | ----------------------- |
 | `fix: …`                                           | patch release (`0.0.X`) |
 | `feat: …`                                          | minor release (`0.X.0`) |
-| `feat!: …` or a `BREAKING CHANGE:` footer          | major release (`X.0.0`) |
+| `feat(scope)!: …` or a `BREAKING CHANGE:` footer   | major release (`X.0.0`) |
 | `docs:` / `chore:` / `refactor:` / `test:` / `ci:` | no release on their own |
+
+Scopes `github`, `repo`, and `contributing` are always release-neutral, including
+with `feat`, `fix`, `perf`, `!`, or a breaking-change footer. Use these scopes only
+for repository automation, repository maintenance, and contribution-process work.
+Product scopes such as `auth`, `workflow-engine`, `cli`, or `docs-site` keep the
+normal release behavior shown above.
 
 **How a release happens.** `master` is protected — there are no direct pushes, and
 only the maintainer merges PRs. Each merge to `master` runs the **Release** workflow:

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:api": "testfold api -e local",
     "test:mcp-tools": "testfold mcp-tools -e local",
     "test:e2e": "testfold e2e -e local",
+    "test:release-policy": "node scripts/verify-release-policy.js",
     "test:remote": "testfold unit workflow integration api e2e mcp-tools -e remote",
     "test:api:remote": "testfold api -e remote",
     "test:mcp-tools:remote": "testfold mcp-tools -e remote",

--- a/scripts/verify-release-policy.js
+++ b/scripts/verify-release-policy.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const TOOLCHAIN = Object.freeze([
+  "semantic-release@24.2.9",
+  "@semantic-release/commit-analyzer@13.0.1",
+  "@semantic-release/release-notes-generator@14.1.1",
+  "conventional-changelog-conventionalcommits@9.3.1",
+]);
+
+const FIXTURES = Object.freeze([
+  ["feat(github): add automation", null],
+  ["fix(repo): repair repository metadata", null],
+  ["perf(contributing): simplify contributor checks", null],
+  ["feat(github)!: replace automation contract", null],
+  ["feat(repo): replace metadata\n\nBREAKING CHANGE: repository-only format", null],
+  ["feat(contributing): replace guidance\n\nBREAKING-CHANGE: repository-only format", null],
+  ["feat(github-api): add webhook", "minor"],
+  ["fix(contributing-tools): repair helper", "patch"],
+  ["feat(api): add endpoint", "minor"],
+  ["fix(api): reject invalid input", "patch"],
+  ["perf(api): reduce latency", "patch"],
+  ["feat(api)!: replace endpoint contract", "major"],
+  ["feat(api): replace endpoint\n\nBREAKING CHANGE: incompatible response", "major"],
+  ["feat(api): replace endpoint\n\nBREAKING-CHANGE: incompatible response", "major"],
+  ["not a conventional commit", null],
+]);
+
+function fail(message, details = "") {
+  const suffix = details ? `\n${details}` : "";
+  throw new Error(`${message}${suffix}`);
+}
+
+async function loadPluginConfig(name) {
+  const config = JSON.parse(await readFile(new URL("../.releaserc.json", import.meta.url), "utf8"));
+  const entry = config.plugins.find((plugin) => Array.isArray(plugin) && plugin[0] === name);
+  if (!entry || typeof entry[1] !== "object") {
+    fail(`Release config does not expose options for ${name}`);
+  }
+  return entry[1];
+}
+
+async function main() {
+  const npmCli = process.env.npm_execpath;
+  if (!npmCli) fail("Run this verifier through npm run test:release-policy");
+
+  const workspace = await mkdtemp(join(tmpdir(), "moira-release-policy-"));
+  try {
+    await writeFile(
+      join(workspace, "package.json"),
+      JSON.stringify({ private: true, type: "module" }),
+      "utf8",
+    );
+    const install = spawnSync(
+      process.execPath,
+      [
+        npmCli,
+        "install",
+        "--ignore-scripts",
+        "--no-audit",
+        "--no-fund",
+        "--no-package-lock",
+        "--save=false",
+        ...TOOLCHAIN,
+      ],
+      { cwd: workspace, encoding: "utf8", maxBuffer: 4 * 1024 * 1024 },
+    );
+    if (install.status !== 0) {
+      fail("Unable to install isolated release-policy toolchain", install.stderr || install.stdout);
+    }
+
+    const analyzerUrl = pathToFileURL(
+      join(workspace, "node_modules/@semantic-release/commit-analyzer/index.js"),
+    );
+    const notesUrl = pathToFileURL(
+      join(workspace, "node_modules/@semantic-release/release-notes-generator/index.js"),
+    );
+    const { analyzeCommits } = await import(analyzerUrl.href);
+    const { generateNotes } = await import(notesUrl.href);
+    const pluginConfig = await loadPluginConfig("@semantic-release/commit-analyzer");
+    const notesConfig = await loadPluginConfig("@semantic-release/release-notes-generator");
+    const context = { logger: { log() {} } };
+
+    for (const [message, expected] of FIXTURES) {
+      const actual =
+        (await analyzeCommits(pluginConfig, { ...context, commits: [{ message }] })) ?? null;
+      if (actual !== expected) {
+        fail(
+          `Release policy mismatch for ${JSON.stringify(message)}`,
+          `expected=${String(expected)} actual=${String(actual)}`,
+        );
+      }
+    }
+    const notes = await generateNotes(notesConfig, {
+      ...context,
+      commits: [
+        {
+          hash: "0123456789abcdef",
+          message: "feat(api): replace endpoint\n\nBREAKING CHANGE: incompatible response",
+        },
+      ],
+      lastRelease: { version: "1.0.0", gitTag: "v1.0.0" },
+      nextRelease: { version: "2.0.0", gitTag: "v2.0.0", type: "major" },
+      options: { repositoryUrl: "https://github.com/moira-mcp/moira" },
+    });
+    if (
+      !notes.includes("replace endpoint") ||
+      !notes.includes("incompatible response") ||
+      !notes.includes("BREAKING CHANGES")
+    ) {
+      fail("Release-notes generator did not render the configured breaking fixture", notes);
+    }
+    process.stdout.write("release policy: official analyzer fixtures passed\n");
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.stack || error.message}\n`);
+  process.exitCode = 1;
+});

--- a/tests/COVERAGE-MAP.md
+++ b/tests/COVERAGE-MAP.md
@@ -318,6 +318,9 @@ level headings classify the tracked test paths listed beneath them.
 
 **unit**
 
+- `tests/unit/github/pr-policy.test.cjs` — bounded title/body policy, same-repository issue linkage, permission-bound no-issue declarations, concrete Testing evidence, per-commit DCO, exact verified Dependabot exception, complete findings and input bounds
+- `tests/unit/github/pr-policy-adapter.test.cjs` — paginated GitHub commit/closing-reference collection, API fact mapping, permission failure semantics and bounded overflow
+- `tests/unit/github/pr-policy-workflow-contract.test.cjs` — stable read-only check, trusted default-branch execution, repair triggers, pinned Actions, contributor/template marker alignment and CODEOWNERS coverage
 - `tests/unit/github/release-policy-contract.test.cjs` — shared analyzer/release-notes preset, exact no-release scopes, deployed/isolated toolchain version parity, CI/root-command wiring, persistent dependency isolation and contributor documentation alignment
 - `tests/unit/github/issue-claim-transitions.test.cjs` — exact command parsing, centralized claim eligibility, ordered coalescing-safe command draining with trusted processed reactions, verified claim/release invariants, trusted human-readable lease record, fault-injected partial/silent GitHub mutations and response replay, ownership-safe compensation, external interleaving preservation, and owner-only release
 - `tests/unit/github/issue-claim-leases.test.cjs` — attributable issue/closing-PR activity, excluded external activity, direct and scheduled renewal, delayed reminder timestamps, retriable visible-reminder cleanup, post-reminder grace, expiry, interrupted/duplicate/malformed record recovery, manual-state preservation, repeat safety, and manual discovery targeting

--- a/tests/COVERAGE-MAP.md
+++ b/tests/COVERAGE-MAP.md
@@ -318,6 +318,7 @@ level headings classify the tracked test paths listed beneath them.
 
 **unit**
 
+- `tests/unit/github/release-policy-contract.test.cjs` — shared analyzer/release-notes preset, exact no-release scopes, deployed/isolated toolchain version parity, CI/root-command wiring, persistent dependency isolation and contributor documentation alignment
 - `tests/unit/github/issue-claim-transitions.test.cjs` — exact command parsing, centralized claim eligibility, ordered coalescing-safe command draining with trusted processed reactions, verified claim/release invariants, trusted human-readable lease record, fault-injected partial/silent GitHub mutations and response replay, ownership-safe compensation, external interleaving preservation, and owner-only release
 - `tests/unit/github/issue-claim-leases.test.cjs` — attributable issue/closing-PR activity, excluded external activity, direct and scheduled renewal, delayed reminder timestamps, retriable visible-reminder cleanup, post-reminder grace, expiry, interrupted/duplicate/malformed record recovery, manual-state preservation, repeat safety, and manual discovery targeting
 - `tests/unit/github/issue-claim-workflow-contract.test.cjs` — trusted default-branch checkout, least-privilege permissions, shared per-issue concurrency, command/schedule/manual triggers, and matrix reconciliation wiring

--- a/tests/unit/github/pr-policy-adapter.test.cjs
+++ b/tests/unit/github/pr-policy-adapter.test.cjs
@@ -1,0 +1,324 @@
+"use strict";
+
+const { describe, expect, test } = require("@jest/globals");
+const adapter = require("../../../.github/scripts/pr-policy-adapter.cjs");
+const policy = require("../../../.github/scripts/pr-policy.cjs");
+
+function pullPayload() {
+  return {
+    repo: { owner: "moira-mcp", repo: "moira" },
+    payload: {
+      pull_request: {
+        number: 7,
+        commits: 101,
+        title: "feat(cli): add command",
+        body: "## Testing\n\n- Command: `npm test`\n- Outcome: passed",
+        user: { login: "alice", id: 10, type: "User" },
+      },
+    },
+  };
+}
+
+function githubHarness({ commits = [], closingIssues = [], permission = "read" } = {}) {
+  return {
+    rest: {
+      pulls: { listCommits: async () => ({ data: commits }) },
+      repos: {
+        getCollaboratorPermissionLevel: async () => ({ data: { permission } }),
+      },
+    },
+    graphql: async () => ({
+      repository: {
+        pullRequest: {
+          closingIssuesReferences: {
+            nodes: closingIssues,
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      },
+    }),
+  };
+}
+
+describe("PR Policy GitHub adapter", () => {
+  test("maps oversized commit text to bounded overflow facts without retaining it", () => {
+    const marker = "UNTRUSTED-MARKER";
+    const fact = adapter.commitFact({
+      sha: "0123456789abcdef",
+      commit: {
+        message: `${marker}${"x".repeat(policy.MAX_COMMIT_MESSAGE_LENGTH)}`,
+        author: {
+          name: `${marker}${"x".repeat(policy.MAX_GIT_IDENTITY_LENGTH)}`,
+          email: "alice@example.com",
+        },
+        verification: { verified: false },
+      },
+      author: { login: "alice", id: 10, type: "User" },
+    });
+    expect(fact).toMatchObject({
+      message: null,
+      messageOverflow: true,
+      gitAuthor: null,
+      gitAuthorOverflow: true,
+    });
+    expect(JSON.stringify(fact)).not.toContain(marker);
+
+    const boundaryMessage = "x".repeat(policy.MAX_COMMIT_MESSAGE_LENGTH);
+    const boundaryName = "李".repeat(policy.MAX_GIT_IDENTITY_LENGTH);
+    const boundaryFact = adapter.commitFact({
+      commit: {
+        message: boundaryMessage,
+        author: { name: boundaryName, email: "li@example.com" },
+      },
+    });
+    expect(boundaryFact).toMatchObject({
+      message: boundaryMessage,
+      messageOverflow: false,
+      gitAuthor: { name: boundaryName, email: "li@example.com" },
+      gitAuthorOverflow: false,
+    });
+  });
+
+  test("maps an oversized pull-request body to a bounded overflow fact", async () => {
+    const marker = "UNTRUSTED-BODY";
+    const context = pullPayload();
+    context.payload.pull_request = {
+      ...context.payload.pull_request,
+      body: `${marker}${"x".repeat(policy.MAX_BODY_LENGTH)}`,
+      commits: 0,
+    };
+    const facts = await adapter.collectFacts({ github: githubHarness(), context });
+    expect(facts).toMatchObject({ body: "", bodyOverflow: true });
+    expect(JSON.stringify(facts)).not.toContain(marker);
+    expect(policy.validatePullRequest(facts).findings.map((item) => item.code)).toContain(
+      "body-too-large",
+    );
+  });
+
+  test("projects every policy finding into one failed GitHub check message", async () => {
+    const context = pullPayload();
+    context.payload.pull_request = {
+      ...context.payload.pull_request,
+      title: "bad title",
+      body: "",
+      commits: 0,
+    };
+    const failures = [];
+    const result = await adapter.run({
+      github: githubHarness(),
+      context,
+      core: { setFailed: (message) => failures.push(message) },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.findings.map((item) => item.code)).toEqual([
+      "title",
+      "testing",
+      "issue-linkage",
+      "commits",
+    ]);
+    expect(failures).toHaveLength(1);
+    for (const item of result.findings) expect(failures[0]).toContain(`- ${item.message}`);
+  });
+
+  test("does not fail the GitHub check when collected facts satisfy policy", async () => {
+    const context = pullPayload();
+    context.payload.pull_request.commits = 1;
+    const commit = {
+      sha: "0123456789abcdef",
+      commit: {
+        message: "feat(cli): add command\n\nSigned-off-by: Alice <alice@example.com>",
+        author: { name: "Alice", email: "alice@example.com" },
+        verification: { verified: false },
+      },
+      author: { login: "alice", id: 10, type: "User" },
+    };
+    const setFailed = jest.fn();
+    const result = await adapter.run({
+      github: githubHarness({
+        commits: [commit],
+        closingIssues: [{ number: 42, repository: { nameWithOwner: "moira-mcp/moira" } }],
+      }),
+      context,
+      core: { setFailed },
+    });
+    expect(result).toEqual({ ok: true, findings: [] });
+    expect(setFailed).not.toHaveBeenCalled();
+  });
+
+  test("collects every commit and closing-reference page and maps GitHub facts", async () => {
+    const commitPages = [
+      Array.from({ length: 100 }, (_, index) => ({
+        sha: `a${index}`,
+        commit: {
+          message: "feat(cli): work",
+          author: { name: "Alice", email: "alice@example.com" },
+          verification: { verified: true },
+        },
+        author: { login: "alice", id: 10, type: "User" },
+      })),
+      [
+        {
+          sha: "last",
+          commit: {
+            message: "fix(cli): finish",
+            author: { name: "Alice", email: "alice@example.com" },
+            verification: { verified: true },
+          },
+          author: { login: "alice", id: 10, type: "User" },
+        },
+      ],
+    ];
+    let graphPage = 0;
+    const github = {
+      rest: {
+        pulls: { listCommits: async ({ page }) => ({ data: commitPages[page - 1] || [] }) },
+        repos: { getCollaboratorPermissionLevel: async () => ({ data: { permission: "write" } }) },
+      },
+      graphql: async (_query, variables) => {
+        const current = graphPage++;
+        return {
+          repository: {
+            pullRequest: {
+              closingIssuesReferences: {
+                nodes: [{ number: current + 1, repository: { nameWithOwner: "moira-mcp/moira" } }],
+                pageInfo: { hasNextPage: current === 0, endCursor: current === 0 ? "next" : null },
+              },
+            },
+          },
+          variables,
+        };
+      },
+    };
+    const facts = await adapter.collectFacts({ github, context: pullPayload() });
+    expect(facts.commits).toHaveLength(101);
+    expect(facts.commits[100]).toMatchObject({ sha: "last", verified: true });
+    expect(facts.closingIssues.map((issue) => issue.number)).toEqual([1, 2]);
+    expect(facts.authorPermission).toBe("write");
+    expect(facts.commitsOverflow).toBe(false);
+    expect(facts.closingIssuesOverflow).toBe(false);
+  });
+
+  test("treats a missing collaborator as no permission and propagates other API failures", async () => {
+    await expect(
+      adapter.getPermission(
+        {
+          rest: {
+            repos: {
+              getCollaboratorPermissionLevel: async () => ({
+                data: { permission: "write", role_name: "maintain" },
+              }),
+            },
+          },
+        },
+        { owner: "moira-mcp", repo: "moira" },
+        "maintainer",
+      ),
+    ).resolves.toBe("maintain");
+    await expect(
+      adapter.getPermission(
+        {
+          rest: {
+            repos: { getCollaboratorPermissionLevel: async () => Promise.reject({ status: 404 }) },
+          },
+        },
+        { owner: "moira-mcp", repo: "moira" },
+        "alice",
+      ),
+    ).resolves.toBeNull();
+    await expect(
+      adapter.getPermission(
+        {
+          rest: {
+            repos: {
+              getCollaboratorPermissionLevel: async () => Promise.reject(new Error("API down")),
+            },
+          },
+        },
+        { owner: "moira-mcp", repo: "moira" },
+        "alice",
+      ),
+    ).rejects.toThrow("API down");
+  });
+
+  test("marks an API-sized commit overflow instead of accepting truncated data", async () => {
+    let calls = 0;
+    const result = await adapter.listCommits(
+      {
+        rest: {
+          pulls: {
+            listCommits: async () => {
+              calls += 1;
+              return { data: [] };
+            },
+          },
+        },
+      },
+      { owner: "moira-mcp", repo: "moira", pull_number: 7 },
+      251,
+    );
+    expect(result.commits).toHaveLength(0);
+    expect(result.overflow).toBe(true);
+    expect(calls).toBe(0);
+  });
+
+  test("fails closed when commit collection races with a changed pull request", async () => {
+    await expect(
+      adapter.listCommits(
+        { rest: { pulls: { listCommits: async () => ({ data: [{ sha: "only-one" }] }) } } },
+        { owner: "moira-mcp", repo: "moira", pull_number: 7 },
+        2,
+      ),
+    ).rejects.toThrow("commit count changed");
+  });
+
+  test("fails closed when GitHub omits the closing-reference contract", async () => {
+    await expect(
+      adapter.listClosingIssues(
+        { graphql: async () => ({ repository: { pullRequest: null } }) },
+        { owner: "moira-mcp", repo: "moira", number: 7 },
+      ),
+    ).rejects.toThrow("did not return pull-request closing references");
+  });
+
+  test("does not require collaborator permission for the exact Dependabot identity", async () => {
+    const context = pullPayload();
+    context.payload.pull_request = {
+      ...context.payload.pull_request,
+      commits: 1,
+      user: { login: "dependabot[bot]", id: 49699333, type: "Bot" },
+    };
+    const github = {
+      rest: {
+        pulls: {
+          listCommits: async () => ({
+            data: [
+              {
+                sha: "dependabot",
+                commit: { message: "build(deps): bump package", verification: { verified: true } },
+                author: { login: "dependabot[bot]", id: 49699333, type: "Bot" },
+              },
+            ],
+          }),
+        },
+        repos: {
+          getCollaboratorPermissionLevel: async () => {
+            throw new Error("must not run");
+          },
+        },
+      },
+      graphql: async () => ({
+        repository: {
+          pullRequest: {
+            closingIssuesReferences: {
+              nodes: [],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        },
+      }),
+    };
+    await expect(adapter.collectFacts({ github, context })).resolves.toMatchObject({
+      authorPermission: null,
+    });
+  });
+});

--- a/tests/unit/github/pr-policy-workflow-contract.test.cjs
+++ b/tests/unit/github/pr-policy-workflow-contract.test.cjs
@@ -61,12 +61,15 @@ describe("PR Policy workflow and contributor contract", () => {
     expect(contributing).toContain("- Command:");
     expect(contributing).toContain("- Outcome:");
     expect(contributing).toContain(policy.DEPENDABOT.login);
+    expect(contributing).toContain("name exactly matches that");
+    expect(contributing).toContain("email matches the Git author email");
     expect(template).toContain("## Related issues");
     expect(template).toContain("Closes #");
     expect(template).toContain("No issue: concrete reason");
     expect(template).toContain("## Testing");
     expect(template).toContain("- Command:");
     expect(template).toContain("- Outcome:");
+    expect(template).toContain("matching its Git author name/email");
     expect(policy.validateTesting(template)).toBeTruthy();
   });
 

--- a/tests/unit/github/pr-policy-workflow-contract.test.cjs
+++ b/tests/unit/github/pr-policy-workflow-contract.test.cjs
@@ -1,0 +1,96 @@
+"use strict";
+
+const { readFileSync } = require("node:fs");
+const { describe, expect, test } = require("@jest/globals");
+const yaml = require("js-yaml");
+const policy = require("../../../.github/scripts/pr-policy.cjs");
+
+describe("PR Policy workflow and contributor contract", () => {
+  const workflow = readFileSync(".github/workflows/pr-policy.yml", "utf8");
+  const workflowDocument = yaml.load(workflow);
+  const contributing = readFileSync("CONTRIBUTING.md", "utf8");
+  const template = readFileSync(".github/PULL_REQUEST_TEMPLATE.md", "utf8");
+  const codeowners = readFileSync(".github/CODEOWNERS", "utf8");
+
+  test("uses a stable read-only check and trusted default-branch code for every repair trigger", () => {
+    expect(workflowDocument.name).toBe("PR Policy");
+    expect(Object.keys(workflowDocument.on)).toEqual(["pull_request"]);
+    expect(workflowDocument.on.pull_request).toEqual({
+      branches: ["master"],
+      types: ["opened", "edited", "reopened", "synchronize"],
+    });
+    expect(workflowDocument.permissions).toEqual({});
+    expect(Object.keys(workflowDocument.jobs)).toEqual(["policy"]);
+    const job = workflowDocument.jobs.policy;
+    expect(job.name).toBe("PR Policy");
+    expect(job.permissions).toEqual({ contents: "read", "pull-requests": "read" });
+    expect(job.steps).toHaveLength(2);
+    expect(job.steps[0]).toEqual({
+      name: "Check out trusted default-branch policy",
+      uses: "actions/checkout@11d5960a326750d5838078e36cf38b85af677262",
+      with: {
+        ref: "${{ github.event.repository.default_branch }}",
+        "persist-credentials": false,
+      },
+    });
+    expect(job.steps[1]).toEqual({
+      name: "Validate pull request",
+      uses: "actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b",
+      with: {
+        script:
+          "const adapter = require('./.github/scripts/pr-policy-adapter.cjs');\n" +
+          "await adapter.run({ github, context, core });\n",
+      },
+    });
+    expect(job.steps.every((step) => step.run === undefined)).toBe(true);
+    expect(workflow).not.toContain("pull_request_target");
+    expect(workflow).not.toMatch(
+      /github\.(?:head_ref|event\.pull_request\.(?:head|merge_commit_sha))/,
+    );
+    expect(workflow).not.toMatch(/uses: actions\/(checkout|github-script)@v\d/);
+  });
+
+  test("keeps title, issue, Testing and bot markers aligned", () => {
+    for (const type of policy.ALLOWED_TYPES) expect(contributing).toContain(`\`${type}\``);
+    for (const scope of policy.NO_ISSUE_SCOPES) expect(contributing).toContain(`\`${scope}\``);
+    for (const permission of policy.NO_ISSUE_PERMISSIONS) {
+      expect(contributing).toContain(`\`${permission}\``);
+    }
+    expect(contributing).toContain("type(scope)[!]: subject");
+    expect(contributing).toContain("No issue: refresh repository policy metadata");
+    expect(contributing).toContain("- Command:");
+    expect(contributing).toContain("- Outcome:");
+    expect(contributing).toContain(policy.DEPENDABOT.login);
+    expect(template).toContain("## Related issues");
+    expect(template).toContain("Closes #");
+    expect(template).toContain("No issue: concrete reason");
+    expect(template).toContain("## Testing");
+    expect(template).toContain("- Command:");
+    expect(template).toContain("- Outcome:");
+    expect(policy.validateTesting(template)).toBeTruthy();
+  });
+
+  test("assigns the documented owner to actual governance and supply-chain boundaries", () => {
+    const activeRules = codeowners
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith("#"));
+    for (const rule of activeRules) {
+      expect(rule.split(/\s+/).slice(1)).toEqual(["@witqq"]);
+    }
+    for (const path of [
+      "/.github/workflows/",
+      "/.github/scripts/",
+      "/.releaserc.json",
+      "/SECURITY.md",
+      "/config/Dockerfile",
+      "/docker-compose*.yml",
+      "/package.json",
+      "/package-lock.json",
+      "/packages/*/package.json",
+      "/packages/*/package-lock.json",
+    ]) {
+      expect(codeowners).toContain(`${path} @witqq`);
+    }
+  });
+});

--- a/tests/unit/github/pr-policy-workflow-contract.test.cjs
+++ b/tests/unit/github/pr-policy-workflow-contract.test.cjs
@@ -13,16 +13,26 @@ describe("PR Policy workflow and contributor contract", () => {
   const codeowners = readFileSync(".github/CODEOWNERS", "utf8");
 
   test("uses a stable read-only check and trusted default-branch code for every repair trigger", () => {
+    expect(Object.keys(workflowDocument)).toEqual(["name", "on", "permissions", "jobs"]);
     expect(workflowDocument.name).toBe("PR Policy");
-    expect(Object.keys(workflowDocument.on)).toEqual(["pull_request"]);
-    expect(workflowDocument.on.pull_request).toEqual({
+    expect(Object.keys(workflowDocument.on)).toEqual(["pull_request_target"]);
+    expect(workflowDocument.on.pull_request_target).toEqual({
       branches: ["master"],
       types: ["opened", "edited", "reopened", "synchronize"],
     });
     expect(workflowDocument.permissions).toEqual({});
     expect(Object.keys(workflowDocument.jobs)).toEqual(["policy"]);
     const job = workflowDocument.jobs.policy;
+    expect(Object.keys(job)).toEqual([
+      "name",
+      "runs-on",
+      "timeout-minutes",
+      "permissions",
+      "steps",
+    ]);
     expect(job.name).toBe("PR Policy");
+    expect(job["runs-on"]).toBe("ubuntu-latest");
+    expect(job["timeout-minutes"]).toBe(10);
     expect(job.permissions).toEqual({ contents: "read", "pull-requests": "read" });
     expect(job.steps).toHaveLength(2);
     expect(job.steps[0]).toEqual({
@@ -43,10 +53,10 @@ describe("PR Policy workflow and contributor contract", () => {
       },
     });
     expect(job.steps.every((step) => step.run === undefined)).toBe(true);
-    expect(workflow).not.toContain("pull_request_target");
     expect(workflow).not.toMatch(
       /github\.(?:head_ref|event\.pull_request\.(?:head|merge_commit_sha))/,
     );
+    expect(workflow).not.toContain("secrets.");
     expect(workflow).not.toMatch(/uses: actions\/(checkout|github-script)@v\d/);
   });
 

--- a/tests/unit/github/pr-policy.test.cjs
+++ b/tests/unit/github/pr-policy.test.cjs
@@ -1,0 +1,316 @@
+"use strict";
+
+const { describe, expect, test } = require("@jest/globals");
+const policy = require("../../../.github/scripts/pr-policy.cjs");
+
+function humanCommit(override = {}) {
+  return {
+    sha: "0123456789abcdef",
+    message: "feat(cli): add command\n\nSigned-off-by: Alice Example <alice@example.com>",
+    gitAuthor: { name: "Alice Example", email: "alice@example.com" },
+    githubAuthor: { login: "alice", id: 10, type: "User" },
+    verified: false,
+    ...override,
+  };
+}
+
+function validInput(override = {}) {
+  return {
+    repository: { owner: "moira-mcp", repo: "moira" },
+    title: "feat(cli): add command",
+    body: [
+      "## Summary",
+      "Add a command.",
+      "",
+      "## Testing",
+      "",
+      "- Command: `npm run test:unit -- --file tests/unit/example.test.ts`",
+      "- Outcome: tests passed",
+    ].join("\n"),
+    author: { login: "alice", id: 10, type: "User" },
+    authorPermission: "read",
+    closingIssues: [{ number: 42, repository: { nameWithOwner: "moira-mcp/moira" } }],
+    commits: [humanCommit()],
+    ...override,
+  };
+}
+
+function codes(result) {
+  return result.findings.map((item) => item.code);
+}
+
+describe("pull-request title policy", () => {
+  test.each([
+    ["feat(cli): add command", { type: "feat", scope: "cli", breaking: false }],
+    [
+      "fix(workflow-engine)!: replace contract",
+      { type: "fix", scope: "workflow-engine", breaking: true },
+    ],
+    ["build(deps-dev): bump package", { type: "build", scope: "deps-dev", breaking: false }],
+  ])("accepts %s", (title, expected) => {
+    expect(policy.parseTitle(title)).toMatchObject({ ok: true, ...expected });
+  });
+
+  test.each([
+    "feat: missing scope",
+    "unknown(cli): subject",
+    "feat(Scope): uppercase scope",
+    "feat(scope): subject",
+    "feat(cli): subject",
+    "feat(cli): tbd",
+    "feat(cli) add command",
+    `feat(cli): ${"x".repeat(policy.MAX_TITLE_LENGTH)}`,
+  ])("rejects invalid or placeholder title %p", (title) => {
+    expect(policy.parseTitle(title).ok).toBe(false);
+  });
+});
+
+describe("issue and Testing contracts", () => {
+  test("accepts a same-repository closing issue and ignores body mentions as evidence", () => {
+    expect(policy.validatePullRequest(validInput()).ok).toBe(true);
+    const mentionOnly = validInput({ closingIssues: [], body: `${validInput().body}\n\nSee #42` });
+    expect(codes(policy.validatePullRequest(mentionOnly))).toContain("issue-linkage");
+    const foreign = validInput({
+      closingIssues: [{ number: 42, repository: { nameWithOwner: "other/project" } }],
+    });
+    expect(codes(policy.validatePullRequest(foreign))).toContain("issue-linkage");
+  });
+
+  test.each(["write", "maintain", "admin"])(
+    "allows concrete repository housekeeping without an issue for %s permission",
+    (authorPermission) => {
+      const input = validInput({
+        title: "ci(github): enforce policy",
+        body: `${validInput().body}\n\nNo issue: maintain repository policy`,
+        closingIssues: [],
+        authorPermission,
+      });
+      expect(policy.validatePullRequest(input).ok).toBe(true);
+    },
+  );
+
+  test.each([
+    ["read permission", { authorPermission: "read" }],
+    ["triage permission", { authorPermission: "triage" }],
+    ["missing permission", { authorPermission: null }],
+    ["product scope", { authorPermission: "admin", title: "feat(cli): add command" }],
+    ["placeholder reason", { authorPermission: "admin", bodyReason: "reason" }],
+  ])("denies the no-issue exception for %s", (_name, change) => {
+    const input = validInput({
+      title: change.title || "ci(github): enforce policy",
+      body: `${validInput().body}\n\nNo issue: ${change.bodyReason || "maintain policy"}`,
+      closingIssues: [],
+      authorPermission: change.authorPermission,
+    });
+    expect(codes(policy.validatePullRequest(input))).toContain("issue-linkage");
+  });
+
+  test.each(["MEMBER", "COLLABORATOR"])(
+    "does not treat %s author association as no-issue authority",
+    (authorAssociation) => {
+      const input = validInput({
+        title: "ci(github): enforce policy",
+        body: `${validInput().body}\n\nNo issue: maintain policy`,
+        closingIssues: [],
+        authorPermission: "read",
+        authorAssociation,
+      });
+      expect(codes(policy.validatePullRequest(input))).toContain("issue-linkage");
+    },
+  );
+
+  test("requires a concrete verification and outcome while accepting a named manual observation", () => {
+    for (const body of [
+      "## Summary\nChange",
+      "## Testing\n\n- Command: <command>\n- Outcome: <outcome>",
+      "## Testing\n\n- [ ] Tests pass locally",
+      "## Testing\n\n- Command: `npm test`",
+    ]) {
+      expect(codes(policy.validatePullRequest(validInput({ body })))).toContain("testing");
+    }
+    const manual = validInput({
+      body: "## Testing\n\n- Manual: opened the issue claim form\n- Outcome: form submitted successfully",
+    });
+    expect(policy.validatePullRequest(manual).ok).toBe(true);
+  });
+});
+
+describe("DCO and bot boundaries", () => {
+  test("requires a matching sign-off for every ordinary commit and reports each mismatch", () => {
+    const input = validInput({
+      commits: [
+        humanCommit({ sha: "aaaaaaaaaaaa", message: "feat(cli): unsigned" }),
+        humanCommit({
+          sha: "bbbbbbbbbbbb",
+          message: "fix(cli): wrong\n\nSigned-off-by: Bob <bob@example.com>",
+        }),
+        humanCommit({ sha: "cccccccccccc", gitAuthor: { name: null, email: null } }),
+      ],
+    });
+    const result = policy.validatePullRequest(input);
+    expect(
+      result.findings.filter((item) => item.code === "dco").map((item) => item.message),
+    ).toEqual([
+      expect.stringContaining("aaaaaaaaaaaa"),
+      expect.stringContaining("bbbbbbbbbbbb"),
+      expect.stringContaining("cccccccccccc"),
+    ]);
+  });
+
+  test("accepts email case normalization but not a different Git author name", () => {
+    expect(
+      policy.dcoMatches(
+        humanCommit({ gitAuthor: { name: "Alice Example", email: "ALICE@EXAMPLE.COM" } }),
+      ),
+    ).toBe(true);
+    expect(
+      policy.dcoMatches(
+        humanCommit({ gitAuthor: { name: "Alice Other", email: "alice@example.com" } }),
+      ),
+    ).toBe(false);
+  });
+
+  test("matches a non-empty one-character Git author without applying body placeholders", () => {
+    expect(
+      policy.dcoMatches(
+        humanCommit({
+          message: "fix(cli): repair\n\nSigned-off-by: 李 <li@example.com>",
+          gitAuthor: { name: "李", email: "li@example.com" },
+        }),
+      ),
+    ).toBe(true);
+    expect(policy.dcoMatches(humanCommit({ gitAuthor: { name: "", email: "" } }))).toBe(false);
+  });
+
+  test("allows only exact verified Dependabot dependency pull requests to bypass human fields", () => {
+    const bot = policy.DEPENDABOT;
+    const exact = validInput({
+      title: "build(deps): bump package",
+      body: "",
+      author: bot,
+      authorPermission: null,
+      closingIssues: [],
+      commits: [
+        {
+          sha: "dddddddddddd",
+          message: "build(deps): bump package",
+          gitAuthor: {
+            name: "dependabot[bot]",
+            email: "49699333+dependabot[bot]@users.noreply.github.com",
+          },
+          githubAuthor: bot,
+          verified: true,
+        },
+      ],
+    });
+    expect(policy.validatePullRequest(exact)).toEqual({ ok: true, findings: [] });
+
+    for (const override of [
+      { author: { ...bot, id: 999 } },
+      { author: { ...bot, login: "dependabot" } },
+      { author: { ...bot, type: "User" } },
+      { title: "build(tooling): bump package" },
+      { title: "build(deps)!: bump package" },
+      { commits: [{ ...exact.commits[0], verified: false }] },
+      { commits: [{ ...exact.commits[0], githubAuthor: { ...bot, id: 999 } }] },
+      { commits: [{ ...exact.commits[0], message: null, messageOverflow: true }] },
+    ]) {
+      expect(policy.validatePullRequest({ ...exact, ...override }).ok).toBe(false);
+    }
+  });
+});
+
+describe("bounded complete findings", () => {
+  test("returns all independent current findings in one result", () => {
+    const result = policy.validatePullRequest({
+      repository: { owner: "moira-mcp", repo: "moira" },
+      title: "bad title",
+      body: "",
+      author: { login: "alice", id: 10, type: "User" },
+      authorPermission: "read",
+      closingIssues: [],
+      commits: [],
+    });
+    expect(codes(result)).toEqual(["title", "testing", "issue-linkage", "commits"]);
+  });
+
+  test("fails closed on body, commit, and closing-reference bounds", () => {
+    const result = policy.validatePullRequest(
+      validInput({
+        body: "x".repeat(policy.MAX_BODY_LENGTH + 1),
+        commitsOverflow: true,
+        closingIssuesOverflow: true,
+      }),
+    );
+    expect(codes(result)).toEqual(
+      expect.arrayContaining(["body-too-large", "commits-too-many", "closing-issues-too-many"]),
+    );
+  });
+
+  test("does not parse oversized body fields and accepts valid content at the boundary", () => {
+    const oversized = validInput({
+      title: "ci(github): maintain policy",
+      authorPermission: "admin",
+      closingIssues: [],
+      body:
+        "x".repeat(policy.MAX_BODY_LENGTH + 1) +
+        "\n## Testing\n- Command: npm test\n- Outcome: passed\nNo issue: maintain policy",
+    });
+    const result = policy.validatePullRequest(oversized);
+    expect(codes(result)).toEqual(
+      expect.arrayContaining(["body-too-large", "testing", "issue-linkage"]),
+    );
+
+    const suffix = "\n## Testing\n\n- Command: npm test\n- Outcome: passed";
+    const boundaryBody = `${"x".repeat(policy.MAX_BODY_LENGTH - suffix.length)}${suffix}`;
+    expect(boundaryBody).toHaveLength(policy.MAX_BODY_LENGTH);
+    expect(policy.validatePullRequest(validInput({ body: boundaryBody })).ok).toBe(true);
+  });
+
+  test("rejects oversized commit text before DCO parsing and accepts the exact boundary", () => {
+    const marker = "UNTRUSTED-MARKER";
+    const oversized = validInput({
+      commits: [
+        humanCommit({
+          message: `${marker}${"x".repeat(policy.MAX_COMMIT_MESSAGE_LENGTH)}`,
+          gitAuthor: {
+            name: `${marker}${"x".repeat(policy.MAX_GIT_IDENTITY_LENGTH)}`,
+            email: "alice@example.com",
+          },
+        }),
+      ],
+    });
+    const result = policy.validatePullRequest(oversized);
+    expect(codes(result)).toEqual(
+      expect.arrayContaining(["commit-message-too-large", "commit-identity-too-large"]),
+    );
+    expect(JSON.stringify(result.findings)).not.toContain(marker);
+    expect(codes(result)).not.toContain("dco");
+
+    const trailer = "\nSigned-off-by: Alice Example <alice@example.com>";
+    const boundaryMessage = `${"x".repeat(
+      policy.MAX_COMMIT_MESSAGE_LENGTH - trailer.length,
+    )}${trailer}`;
+    expect(boundaryMessage).toHaveLength(policy.MAX_COMMIT_MESSAGE_LENGTH);
+    expect(
+      policy.validatePullRequest(
+        validInput({ commits: [humanCommit({ message: boundaryMessage })] }),
+      ).ok,
+    ).toBe(true);
+
+    const boundaryName = "李".repeat(policy.MAX_GIT_IDENTITY_LENGTH);
+    expect(boundaryName).toHaveLength(policy.MAX_GIT_IDENTITY_LENGTH);
+    expect(
+      policy.validatePullRequest(
+        validInput({
+          commits: [
+            humanCommit({
+              message: `fix(cli): repair\n\nSigned-off-by: ${boundaryName} <li@example.com>`,
+              gitAuthor: { name: boundaryName, email: "li@example.com" },
+            }),
+          ],
+        }),
+      ).ok,
+    ).toBe(true);
+  });
+});

--- a/tests/unit/github/release-policy-contract.test.cjs
+++ b/tests/unit/github/release-policy-contract.test.cjs
@@ -1,0 +1,86 @@
+"use strict";
+
+const { readFileSync } = require("node:fs");
+const { describe, expect, test } = require("@jest/globals");
+
+describe("release policy persistent contract", () => {
+  const config = JSON.parse(readFileSync(".releaserc.json", "utf8"));
+  const releaseWorkflow = readFileSync(".github/workflows/release.yml", "utf8");
+  const ciWorkflow = readFileSync(".github/workflows/ci.yml", "utf8");
+  const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
+  const packageLock = JSON.parse(readFileSync("package-lock.json", "utf8"));
+  const verifier = readFileSync("scripts/verify-release-policy.js", "utf8");
+  const contributing = readFileSync("CONTRIBUTING.md", "utf8");
+
+  test("uses one conventionalcommits parser contract and exact no-release scopes", () => {
+    const analyzer = config.plugins.find(
+      (plugin) => Array.isArray(plugin) && plugin[0] === "@semantic-release/commit-analyzer",
+    );
+    const notes = config.plugins.find(
+      (plugin) =>
+        Array.isArray(plugin) && plugin[0] === "@semantic-release/release-notes-generator",
+    );
+    expect(analyzer[1].preset).toBe("conventionalcommits");
+    expect(notes[1].preset).toBe("conventionalcommits");
+    expect(analyzer[1].parserOpts).toEqual(notes[1].parserOpts);
+    expect(analyzer[1].releaseRules).toEqual([
+      { scope: "github", release: false },
+      { scope: "repo", release: false },
+      { scope: "contributing", release: false },
+    ]);
+  });
+
+  test("pins the deployed and isolated official analyzer toolchains identically", () => {
+    for (const version of [
+      "24.2.9",
+      "@semantic-release/commit-analyzer@13.0.1",
+      "@semantic-release/release-notes-generator@14.1.1",
+      "conventional-changelog-conventionalcommits@9.3.1",
+    ]) {
+      expect(releaseWorkflow).toContain(version);
+      expect(verifier).toContain(version);
+    }
+    expect(packageJson.scripts["test:release-policy"]).toBe(
+      "node scripts/verify-release-policy.js",
+    );
+    expect(ciWorkflow).toContain("npm run test:release-policy");
+  });
+
+  test("keeps release tooling outside the persistent dependency graph", () => {
+    for (const field of [
+      "dependencies",
+      "devDependencies",
+      "optionalDependencies",
+      "peerDependencies",
+    ]) {
+      expect(packageJson[field] || {}).not.toHaveProperty("semantic-release");
+      expect(packageJson[field] || {}).not.toHaveProperty("@semantic-release/commit-analyzer");
+      expect(packageJson[field] || {}).not.toHaveProperty(
+        "@semantic-release/release-notes-generator",
+      );
+      expect(packageJson[field] || {}).not.toHaveProperty(
+        "conventional-changelog-conventionalcommits",
+      );
+    }
+    expect(verifier).toContain("mkdtemp");
+    expect(verifier).toContain("--ignore-scripts");
+    expect(verifier).toContain("--no-package-lock");
+    expect(verifier).toContain("await rm(workspace, { recursive: true, force: true })");
+    const persistentPackages = Object.keys(packageLock.packages || {});
+    for (const name of [
+      "semantic-release",
+      "@semantic-release/commit-analyzer",
+      "@semantic-release/release-notes-generator",
+      "conventional-changelog-conventionalcommits",
+    ]) {
+      expect(persistentPackages.some((path) => path.endsWith(`/node_modules/${name}`))).toBe(false);
+      expect(persistentPackages).not.toContain(`node_modules/${name}`);
+    }
+  });
+
+  test("documents product and repository-only release behavior", () => {
+    expect(contributing).toContain("Scopes `github`, `repo`, and `contributing`");
+    expect(contributing).toContain("`feat(scope)!: …`");
+    expect(contributing).toContain("`BREAKING CHANGE:`");
+  });
+});


### PR DESCRIPTION
## Summary

- keep repository-only scopes from producing product releases
- add a trusted read-only PR Policy check, CODEOWNERS, contributor contract, and regression evidence

No issue: establish repository release and pull-request governance

## Testing

- Command: npm run test:unit
- Outcome: 1681 tests passed before final focused repairs; all later changed policy, adapter, workflow, and documentation tests passed
- Command: npm run test:release-policy
- Outcome: official pinned analyzer and release-notes fixtures passed
- Command: full repository ESLint and Prettier checks
- Outcome: ESLint completed with zero errors and Prettier passed

## Notes

Branch settings and security-alert remediation remain in the parent task after this workflow is active.