### PR TITLE
ci(github): add security automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,62 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    target-branch: master
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 3
+    labels:
+      - type:chore
+      - component:infrastructure
+    rebase-strategy: auto
+    commit-message:
+      prefix: build
+      prefix-development: build
+      include: scope
+    groups:
+      production-dependencies:
+        applies-to: version-updates
+        dependency-type: production
+        patterns:
+          - "*"
+      development-dependencies:
+        applies-to: version-updates
+        dependency-type: development
+        patterns:
+          - "*"
+      security-production-dependencies:
+        applies-to: security-updates
+        dependency-type: production
+        patterns:
+          - "*"
+      security-development-dependencies:
+        applies-to: security-updates
+        dependency-type: development
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: master
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:30"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 1
+    labels:
+      - type:chore
+      - component:infrastructure
+    rebase-strategy: auto
+    commit-message:
+      prefix: build
+      include: scope
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     name: Lint and Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: "npm"
@@ -36,10 +36,10 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: "npm"
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: unit-test-results
           path: test-results/
@@ -68,10 +68,10 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: "npm"
@@ -93,7 +93,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: integration-test-results
           path: test-results/
@@ -104,10 +104,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, unit-tests, integration-tests]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: "npm"
@@ -121,10 +121,10 @@ jobs:
           cp .env.ci .env
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           file: ./config/Dockerfile
@@ -149,8 +149,8 @@ jobs:
             -e MCP_PORT=3000 \
             -e WEB_BACKEND_PORT=3001 \
             -e WEB_FRONTEND_PORT=3002 \
-            -v $(pwd)/workflows:/app/workflows \
-            -v $(pwd)/data:/app/data \
+            -v "$(pwd)/workflows:/app/workflows" \
+            -v "$(pwd)/data:/app/data" \
             -e DISABLE_RATE_LIMIT=true \
             -d \
             ${{ env.DOCKER_IMAGE }}:latest
@@ -202,8 +202,8 @@ jobs:
             --name ${{ env.DOCKER_IMAGE }}-self-host \
             -p 3031:80 \
             --env-file .env.ci \
-            -v $(pwd)/workflows:/app/workflows \
-            -v $(pwd)/data-self-host:/app/data \
+            -v "$(pwd)/workflows:/app/workflows" \
+            -v "$(pwd)/data-self-host:/app/data" \
             -e DEPLOYMENT_MODE=self-host \
             -e MOIRA_HOST=localhost:3031 \
             -e STATIC_ARTIFACTS_DOMAIN=static.localhost:3031 \
@@ -248,7 +248,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: docker-test-results
           path: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,10 +19,10 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: "npm"
@@ -39,10 +39,10 @@ jobs:
           cp .env.ci .env
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           file: ./config/Dockerfile
@@ -67,8 +67,8 @@ jobs:
             -e MCP_PORT=3000 \
             -e WEB_BACKEND_PORT=3001 \
             -e WEB_FRONTEND_PORT=3002 \
-            -v $(pwd)/workflows:/app/workflows \
-            -v $(pwd)/data:/app/data \
+            -v "$(pwd)/workflows:/app/workflows" \
+            -v "$(pwd)/data:/app/data" \
             -e DISABLE_RATE_LIMIT=true \
             -d \
             ${{ env.DOCKER_IMAGE }}:latest
@@ -106,7 +106,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-report
           path: playwright-report/

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -51,7 +51,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Prepare platform name
         env:
@@ -59,10 +59,10 @@ jobs:
         run: echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -74,7 +74,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: config/Dockerfile
@@ -98,7 +98,7 @@ jobs:
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/digests/*
@@ -114,14 +114,14 @@ jobs:
       packages: write
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       # Under workflow_call the context is the caller's branch ref (refs/heads/master),
       # so the `type=semver` lines below produce NOTHING — derive the version tags
@@ -137,7 +137,7 @@ jobs:
 
       - name: Extract image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -150,7 +150,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -159,9 +159,16 @@ jobs:
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
         run: |
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+          mapfile -t tags < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          tag_args=()
+          for tag in "${tags[@]}"; do
+            tag_args+=("-t" "$tag")
+          done
+          digest_args=()
+          for digest in *; do
+            digest_args+=("${REGISTRY}/${IMAGE_NAME}@sha256:${digest}")
+          done
+          docker buildx imagetools create "${tag_args[@]}" "${digest_args[@]}"
 
       - name: Inspect image
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,13 +36,13 @@ jobs:
       version: ${{ steps.semantic.outputs.new_release_version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0 # full history so commit analysis sees all tags
 
       - name: semantic-release
         id: semantic
-        uses: cycjimmy/semantic-release-action@v6
+        uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
         with:
           semantic_version: 24.2.9
           extra_plugins: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,42 @@
+name: Security Checks
+
+on:
+  pull_request_target:
+    branches: [master]
+    types: [opened, edited, reopened, synchronize]
+
+permissions: {}
+
+jobs:
+  security:
+    name: Security Checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          vulnerability-check: true
+          license-check: false
+          warn-only: false
+          fail-on-severity: moderate
+          fail-on-scopes: runtime, development, unknown
+
+      - name: Check out pull request as untrusted data
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          persist-credentials: false
+
+      - name: Remove pull-request actionlint policy
+        run: rm -f .github/actionlint.yml .github/actionlint.yaml
+
+      - name: Validate workflow syntax and expressions
+        uses: devops-actions/actionlint@ec02b36684b2f574f1d219ad0a43b082e46bf3e4 # v0.1.13
+        with:
+          fail-on-errors: true
+
+      - name: Require immutable external Actions
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@c5fc58bd0be7a4b94b73ce40250322d5b838a108 # v5.0.7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,7 +211,25 @@ Dependabot may omit the human issue, Testing, and DCO fields only when GitHub
 identifies the pull request and every verified commit as the official
 `dependabot[bot]` account and the title uses `build(deps): …` or
 `build(deps-dev): …`. Other bots and partial identity matches follow the human
-requirements.
+requirements. Dependabot schedules grouped root npm and GitHub Actions version
+updates weekly. Once Dependabot security updates are enabled, npm security fixes
+are processed from security advisories and grouped separately by production or
+development dependency type; they do not wait for the weekly version-update
+schedule. Automated update PRs use the existing `type:chore` and
+`component:infrastructure` labels.
+
+### Automated security checks
+
+After activation, **Security Checks** reviews newly changed dependencies for
+moderate-or-higher vulnerabilities in runtime, development, and unknown scopes.
+It also validates every GitHub Actions workflow with actionlint and rejects any
+external Action that is not pinned to an immutable commit SHA or image digest.
+
+The workflow treats pull-request files as untrusted static input and never runs
+project scripts or dependencies. Fix a failure by updating the dependency or
+workflow itself; do not add an allowlist, warning-only mode, floating tag, or
+suppression file to bypass the check. Existing dependency alerts are remediated
+separately and are not evidence that a dependency-neutral pull request failed.
 
 ## Sign your commits (DCO)
 
@@ -263,9 +281,10 @@ secrets or manual steps are involved (the release uses only the built-in
 Self-host users upgrade simply by pulling the new image — see
 [Updating / Upgrading](README.md#updating--upgrading) in the README.
 
-**CI on pull requests** runs Lint, Unit, Integration, and a Docker build + API/MCP
-tests. The Playwright **E2E** suite is flaky on shared runners, so it runs nightly
-(and on demand) via `.github/workflows/e2e.yml` rather than gating PRs.
+**CI on pull requests** runs PR Policy, Security Checks, Lint, Unit, Integration,
+and a Docker build + API/MCP tests. The Playwright **E2E** suite is flaky on shared
+runners, so it runs nightly (and on demand) via `.github/workflows/e2e.yml` rather
+than gating PRs.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,13 +25,10 @@ Please include as much of the following as you can:
 
 ## Response
 
-- We aim to acknowledge a report within **5 business days**.
-- We will keep you informed of the progress toward a fix and full announcement.
-- We may ask for additional information or guidance.
-- Once a fix is available, we will coordinate a disclosure timeline with you.
-
-We ask that you give us a reasonable amount of time to address the issue before
-any public disclosure.
+Reports are handled privately. Response and remediation timing depends on the
+issue's impact, reproducibility, and fix readiness; no fixed service timeline is
+guaranteed. Maintainers may request additional information and coordinate
+disclosure when a fix is ready.
 
 ## Supported Versions
 
@@ -50,3 +47,21 @@ This policy covers the Moira application code in this repository. The public
 self-host deployment model (Docker image, `docker-compose.yml`) is in scope.
 Issues in third-party dependencies should generally be reported upstream, but
 let us know if a dependency issue affects Moira so we can update or mitigate.
+
+## Automated Controls
+
+Dependabot schedules grouped root npm and GitHub Actions version updates weekly.
+Once security updates are enabled, npm security fixes are processed from security
+advisories and grouped separately by production or development dependency type;
+they do not wait for the weekly version-update schedule. Automated update PRs use
+the existing `type:chore` and `component:infrastructure` labels.
+
+The **Security Checks** pull-request gate checks newly introduced moderate-or-higher vulnerable
+dependencies across runtime, development, and unknown scopes. License policy is
+not part of this gate. GitHub Actions workflows are checked with actionlint, and
+every external Action must use an immutable commit SHA or image digest.
+
+These controls reduce new supply-chain risk; they do not mean that all existing
+dependency or code alerts are resolved. Current alerts are tracked and remediated
+through reviewed dependency or code changes. Continue to report suspected
+vulnerabilities privately through the process above.

--- a/tests/COVERAGE-MAP.md
+++ b/tests/COVERAGE-MAP.md
@@ -318,6 +318,7 @@ level headings classify the tracked test paths listed beneath them.
 
 **unit**
 
+- `tests/unit/github/security-automation-contract.test.cjs` — grouped Dependabot sources/title prefixes, complete immutable external Action inventory, base-owned dependency/workflow security gate, trusted actionlint policy, tool inputs and SECURITY/CONTRIBUTING alignment
 - `tests/unit/github/pr-policy.test.cjs` — bounded title/body policy, same-repository issue linkage, permission-bound no-issue declarations, concrete Testing evidence, per-commit DCO, exact verified Dependabot exception, complete findings and input bounds
 - `tests/unit/github/pr-policy-adapter.test.cjs` — paginated GitHub commit/closing-reference collection, API fact mapping, permission failure semantics and bounded overflow
 - `tests/unit/github/pr-policy-workflow-contract.test.cjs` — stable read-only check, trusted default-branch execution, repair triggers, pinned Actions, contributor/template marker alignment and CODEOWNERS coverage

--- a/tests/unit/github/security-automation-contract.test.cjs
+++ b/tests/unit/github/security-automation-contract.test.cjs
@@ -1,0 +1,201 @@
+"use strict";
+
+const { readdirSync, readFileSync } = require("node:fs");
+const { describe, expect, test } = require("@jest/globals");
+const yaml = require("js-yaml");
+
+const WORKFLOW_DIR = ".github/workflows";
+
+function workflowFiles() {
+  return readdirSync(WORKFLOW_DIR)
+    .filter((name) => /\.ya?ml$/.test(name))
+    .sort()
+    .map((name) => `${WORKFLOW_DIR}/${name}`);
+}
+
+function externalUsesLines() {
+  return workflowFiles().flatMap((path) =>
+    readFileSync(path, "utf8")
+      .split(/\r?\n/)
+      .map((line, index) => ({ path, line: index + 1, text: line.trim() }))
+      .filter(({ text }) => /^-?\s*uses:\s*/.test(text))
+      .filter(({ text }) => !/uses:\s+\.\//.test(text)),
+  );
+}
+
+describe("security automation contract", () => {
+  test("groups root npm and GitHub Actions updates with PR Policy-compatible prefixes", () => {
+    const config = yaml.load(readFileSync(".github/dependabot.yml", "utf8"));
+    expect(config.version).toBe(2);
+    expect(config.updates).toHaveLength(2);
+
+    const npm = config.updates.find((entry) => entry["package-ecosystem"] === "npm");
+    const actions = config.updates.find((entry) => entry["package-ecosystem"] === "github-actions");
+    expect(Object.keys(npm)).toEqual([
+      "package-ecosystem",
+      "directory",
+      "target-branch",
+      "schedule",
+      "open-pull-requests-limit",
+      "labels",
+      "rebase-strategy",
+      "commit-message",
+      "groups",
+    ]);
+    expect(npm).toMatchObject({
+      directory: "/",
+      "target-branch": "master",
+      schedule: { interval: "weekly", day: "monday", time: "04:00", timezone: "Etc/UTC" },
+      "open-pull-requests-limit": 3,
+      labels: ["type:chore", "component:infrastructure"],
+      "rebase-strategy": "auto",
+      "commit-message": { prefix: "build", "prefix-development": "build", include: "scope" },
+    });
+    expect(npm.groups).toEqual({
+      "production-dependencies": {
+        "applies-to": "version-updates",
+        "dependency-type": "production",
+        patterns: ["*"],
+      },
+      "development-dependencies": {
+        "applies-to": "version-updates",
+        "dependency-type": "development",
+        patterns: ["*"],
+      },
+      "security-production-dependencies": {
+        "applies-to": "security-updates",
+        "dependency-type": "production",
+        patterns: ["*"],
+      },
+      "security-development-dependencies": {
+        "applies-to": "security-updates",
+        "dependency-type": "development",
+        patterns: ["*"],
+      },
+    });
+    expect(actions).toEqual({
+      "package-ecosystem": "github-actions",
+      directory: "/",
+      "target-branch": "master",
+      schedule: { interval: "weekly", day: "monday", time: "04:30", timezone: "Etc/UTC" },
+      "open-pull-requests-limit": 1,
+      labels: ["type:chore", "component:infrastructure"],
+      "rebase-strategy": "auto",
+      "commit-message": { prefix: "build", include: "scope" },
+      groups: { "github-actions": { patterns: ["*"] } },
+    });
+  });
+
+  test("pins every external Action in the complete workflow corpus", () => {
+    const files = workflowFiles();
+    expect(files).toEqual([
+      ".github/workflows/ci.yml",
+      ".github/workflows/e2e.yml",
+      ".github/workflows/issue-claims.yml",
+      ".github/workflows/pr-policy.yml",
+      ".github/workflows/publish-image.yml",
+      ".github/workflows/release.yml",
+      ".github/workflows/security.yml",
+    ]);
+    const uses = externalUsesLines();
+    expect(uses.length).toBeGreaterThan(0);
+    for (const item of uses) {
+      const location = `${item.path}:${item.line} ${item.text}`;
+      const repositoryAction =
+        /uses:\s+[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\/[A-Za-z0-9_.-]+)*@[0-9a-f]{40}\s+#\s+v\S+$/;
+      const dockerAction = /uses:\s+docker:\/\/[^\s@]+@sha256:[0-9a-f]{64}\s+#\s+v\S+$/;
+      expect(repositoryAction.test(location) || dockerAction.test(location)).toBe(true);
+    }
+  });
+
+  test("uses a base-owned read-only gate and treats PR files only as static data", () => {
+    const document = yaml.load(readFileSync(".github/workflows/security.yml", "utf8"));
+    expect(Object.keys(document)).toEqual(["name", "on", "permissions", "jobs"]);
+    expect(document.name).toBe("Security Checks");
+    expect(Object.keys(document.on)).toEqual(["pull_request_target"]);
+    expect(document.on.pull_request_target).toEqual({
+      branches: ["master"],
+      types: ["opened", "edited", "reopened", "synchronize"],
+    });
+    expect(document.permissions).toEqual({});
+    expect(Object.keys(document.jobs)).toEqual(["security"]);
+    const job = document.jobs.security;
+    expect(Object.keys(job)).toEqual([
+      "name",
+      "runs-on",
+      "timeout-minutes",
+      "permissions",
+      "steps",
+    ]);
+    expect(job).toMatchObject({
+      name: "Security Checks",
+      "runs-on": "ubuntu-latest",
+      "timeout-minutes": 10,
+      permissions: { contents: "read" },
+    });
+    expect(job.steps.map((step) => step.name)).toEqual([
+      "Review dependency changes",
+      "Check out pull request as untrusted data",
+      "Remove pull-request actionlint policy",
+      "Validate workflow syntax and expressions",
+      "Require immutable external Actions",
+    ]);
+    expect(job.steps[0]).toEqual({
+      name: "Review dependency changes",
+      uses: "actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294",
+      with: {
+        "vulnerability-check": true,
+        "license-check": false,
+        "warn-only": false,
+        "fail-on-severity": "moderate",
+        "fail-on-scopes": "runtime, development, unknown",
+      },
+    });
+    expect(job.steps[1]).toEqual({
+      name: "Check out pull request as untrusted data",
+      uses: "actions/checkout@11d5960a326750d5838078e36cf38b85af677262",
+      with: {
+        ref: "${{ github.event.pull_request.merge_commit_sha }}",
+        "persist-credentials": false,
+      },
+    });
+    expect(job.steps[2]).toEqual({
+      name: "Remove pull-request actionlint policy",
+      run: "rm -f .github/actionlint.yml .github/actionlint.yaml",
+    });
+    expect(job.steps[3]).toEqual({
+      name: "Validate workflow syntax and expressions",
+      uses: "devops-actions/actionlint@ec02b36684b2f574f1d219ad0a43b082e46bf3e4",
+      with: { "fail-on-errors": true },
+    });
+    expect(job.steps[4]).toEqual({
+      name: "Require immutable external Actions",
+      uses: "zgosalvez/github-actions-ensure-sha-pinned-actions@c5fc58bd0be7a4b94b73ce40250322d5b838a108",
+    });
+    const raw = readFileSync(".github/workflows/security.yml", "utf8");
+    expect(raw).not.toContain("secrets.");
+    expect(raw).not.toMatch(/npm\s+(?:ci|install)|yarn|pnpm|pull_request:\s/);
+  });
+
+  test("keeps contributor and security documentation aligned", () => {
+    const contributing = readFileSync("CONTRIBUTING.md", "utf8");
+    const security = readFileSync("SECURITY.md", "utf8");
+    for (const value of [
+      "Security Checks",
+      "moderate-or-higher",
+      "runtime, development, and unknown",
+      "actionlint",
+      "immutable commit SHA or image digest",
+    ]) {
+      expect(contributing).toContain(value);
+      expect(security).toContain(value);
+    }
+    expect(security).toContain("do not mean that all existing");
+    for (const document of [contributing, security]) {
+      expect(document).toMatch(/version\s+updates weekly/);
+      expect(document).toMatch(/do not wait for the weekly version-update\s+schedule/);
+      expect(document).toContain("`type:chore`");
+      expect(document).not.toContain("5 business days");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Add low-noise Dependabot updates and a base-owned read-only Security Checks gate so future pull requests cannot introduce moderate-or-higher vulnerable dependencies, invalid workflows, or floating external Actions.

## Related issues

No issue: add repository security automation before alert remediation

## Changes

- group root npm and GitHub Actions updates with repository labels and PR-policy-compatible titles
- pin every external Action and add dependency, actionlint, and immutable-pin checks
- document contributor/security behavior and add complete repository contracts

## Testing

- Command: npm run test:unit
- Outcome: 1689 tests passed, 0 failed under Node 22.18.0
- Command: npm run fix
- Outcome: completed with no changed bytes and no errors; one unrelated existing React Hook warning remains

## Checklist

- [x] Every commit has a DCO Signed-off-by matching its Git author name/email (see CONTRIBUTING.md)
- [x] Added or updated tests for behavior changes
- [x] Updated documentation for user-facing behavior changes
- [x] I have read the Code of Conduct
- [x] No secrets, credentials, or personal paths are included