### PR TITLE
fix(security): normalize generated identifiers linearly

### DIFF
--- a/packages/shared/src/validation/slug-handle.ts
+++ b/packages/shared/src/validation/slug-handle.ts
@@ -28,6 +28,23 @@ function hasValidSlugCharacters(value: string): boolean {
   return true;
 }
 
+function normalizeIdentifierCharacters(value: string): string {
+  let identifier = "";
+  let separatorPending = false;
+
+  for (const character of value.toLowerCase()) {
+    if (isLowerAlphanumeric(character)) {
+      if (separatorPending && identifier.length > 0) identifier += "-";
+      identifier += character;
+      separatorPending = false;
+    } else {
+      separatorPending = identifier.length > 0;
+    }
+  }
+
+  return identifier;
+}
+
 // ===== Validation Functions =====
 
 /**
@@ -148,8 +165,7 @@ export function normalizeHandle(handle: string): string {
  */
 export function generateHandleFromEmail(email: string): string {
   const prefix = email.split("@")[0] || "";
-  let handle = prefix.toLowerCase().replace(/[^a-z0-9]/g, "-");
-  handle = handle.replace(/-+/g, "-").replace(/^-+|-+$/g, "");
+  let handle = normalizeIdentifierCharacters(prefix);
 
   while (handle.length < HANDLE_MIN_LENGTH) {
     handle += Math.random().toString(36).charAt(2);
@@ -191,17 +207,7 @@ export function generateDefaultSlug(): string {
  * @returns Generated slug
  */
 export function generateSlugFromName(name: string): string {
-  let slug = "";
-  let separatorPending = false;
-  for (const character of name.toLowerCase()) {
-    if (isLowerAlphanumeric(character)) {
-      if (separatorPending && slug.length > 0) slug += "-";
-      slug += character;
-      separatorPending = false;
-    } else {
-      separatorPending = slug.length > 0;
-    }
-  }
+  let slug = normalizeIdentifierCharacters(name);
 
   // Ensure minimum length
   if (slug.length < SLUG_MIN_LENGTH) {

--- a/tests/unit/shared/slug-handle-validation.test.ts
+++ b/tests/unit/shared/slug-handle-validation.test.ts
@@ -10,6 +10,7 @@ import {
   normalizeSlug,
   normalizeHandle,
   generateDefaultSlug,
+  generateHandleFromEmail,
   generateSlugFromName,
   parseWorkflowReference,
   createWorkflowReference,
@@ -251,6 +252,16 @@ describe("Handle Validation", () => {
     it("does basic normalization only (lowercase and trim)", () => {
       // normalizeHandle only lowercases and trims, does not transform characters
       expect(normalizeHandle("john_doe")).toBe("john_doe");
+    });
+  });
+
+  describe("generateHandleFromEmail", () => {
+    it("normalizes long punctuation runs in bounded time", () => {
+      const startedAt = performance.now();
+      const handle = generateHandleFromEmail(`john${"-".repeat(50_000)}doe@example.com`);
+
+      expect(performance.now() - startedAt).toBeLessThan(100);
+      expect(handle).toBe("john-doe");
     });
   });
 });


### PR DESCRIPTION
## Summary

- replace the remaining regex-based email-handle normalization with the shared linear identifier scanner
- reuse the same bounded primitive for workflow-name slug generation
- add an adversarial handle regression test for long punctuation runs

## Related issues

Closes #110

## Testing

- Command: npm run test:unit -- -- tests/unit/shared/slug-handle-validation.test.ts; eslint and prettier checks for both changed files
- Outcome: focused unit file passed 56/56; ESLint completed without findings; Prettier reported both files formatted

## Checklist

- [x] Every commit has a DCO Signed-off-by matching its Git author name/email
- [x] Added or updated tests for behavior changes
- [x] Documentation is unaffected because public behavior is preserved
- [x] I have read the Code of Conduct
- [x] No secrets, credentials, or personal paths are included

The single source commit is authored and committed by wit_qq <belyiwork@mail.ru> and includes a DCO sign-off.
