### PR TITLE
docs(reference): align MCP tools with public API

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,15 +212,14 @@ identifies the pull request and every verified commit as the official
 `dependabot[bot]` account and the title uses `build(deps): …` or
 `build(deps-dev): …`. Other bots and partial identity matches follow the human
 requirements. Dependabot schedules grouped root npm and GitHub Actions version
-updates weekly. Once Dependabot security updates are enabled, npm security fixes
-are processed from security advisories and grouped separately by production or
-development dependency type; they do not wait for the weekly version-update
-schedule. Automated update PRs use the existing `type:chore` and
+updates weekly. Npm security fixes from advisories use separate production and
+development groups. They do not wait for the weekly version-update schedule.
+Automated update PRs use the existing `type:chore` and
 `component:infrastructure` labels.
 
 ### Automated security checks
 
-After activation, **Security Checks** reviews newly changed dependencies for
+**Security Checks** reviews newly changed dependencies for
 moderate-or-higher vulnerabilities in runtime, development, and unknown scopes.
 It also validates every GitHub Actions workflow with actionlint and rejects any
 external Action that is not pinned to an immutable commit SHA or image digest.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,9 +51,8 @@ let us know if a dependency issue affects Moira so we can update or mitigate.
 ## Automated Controls
 
 Dependabot schedules grouped root npm and GitHub Actions version updates weekly.
-Once security updates are enabled, npm security fixes are processed from security
-advisories and grouped separately by production or development dependency type;
-they do not wait for the weekly version-update schedule. Automated update PRs use
+Npm security fixes from advisories use separate production and development groups.
+They do not wait for the weekly version-update schedule. Automated update PRs use
 the existing `type:chore` and `component:infrastructure` labels.
 
 The **Security Checks** pull-request gate checks newly introduced moderate-or-higher vulnerable

--- a/packages/docs/src/content/docs/docs/reference/tools.mdx
+++ b/packages/docs/src/content/docs/docs/reference/tools.mdx
@@ -20,6 +20,7 @@ Moira exposes workflow execution capabilities through MCP tools. This reference 
 - `session` - Get user, executions, or step info
 - `settings` - Manage user settings
 - `notes` - Persistent note storage with versioning
+- `lock` - Inspect, create, or unlock execution locks
 
 ### Content & Artifacts
 
@@ -37,21 +38,27 @@ Moira exposes workflow execution capabilities through MCP tools. This reference 
 
 ## list
 
-Lists all available workflow templates with validation status.
+Lists workflows accessible to the current user with filtering, sorting, and pagination.
 
-**Parameters:** None
+**Parameters:**
+
+- `search` (string, optional) - Search workflow names and descriptions
+- `visibility` (`"public" | "private" | "all"`, optional) - Visibility filter
+- `sort` (`"createdAt" | "name"`, optional, default: `"createdAt"`) - Sort field
+- `sortOrder` (`"asc" | "desc"`, optional, default: `"desc"`) - Sort order
+- `limit` (number, optional, default: 20) - Results per page (1–100)
+- `offset` (number, optional, default: 0) - Pagination offset
 
 **Returns:**
 
-- Array of workflow objects with metadata
-- Validation status for each workflow
-- File paths and last modified timestamps
+- `workflows` - Workflow summaries with ID, slug, owner handle, name, version, description, visibility, and creation time
+- `total` - Total number matching the filters
 
 **Example:**
 
 ```json
-list()
-→ [{ id: "example", name: "Example Workflow", valid: true, ... }]
+list({ search: "review", visibility: "public", limit: 20, offset: 0 })
+→ { workflows: [{ id: "moira/review", slug: "review", ownerHandle: "moira", ... }], total: 1 }
 ```
 
 ---
@@ -76,17 +83,17 @@ Starts new workflow execution.
 **Example:**
 
 ```json
-start({ workflowId: "example", note: "Feature implementation task" })
+start({ workflowId: "example", note: "Feature implementation task", parentExecutionId: "none" })
 → { processId: "abc-123", directive: "...", ... }
 ```
 
 **Parent Execution Linking:**
 
 ```json
-start({ workflowId: "sub-workflow", parentExecutionId: "parent-abc-123" })
+start({ workflowId: "sub-workflow", parentExecutionId: "123e4567-e89b-42d3-a456-426614174000" })
 ```
 
-When child workflow completes, system returns continuation info for the parent execution.
+Replace the example UUID with the `processId` of an existing parent execution. When the child workflow completes, the system returns continuation info for that parent.
 
 ---
 
@@ -97,7 +104,8 @@ Advances workflow execution with agent input.
 **Parameters:**
 
 - `processId` (string, required) - Process ID from start
-- `input` (any) - Agent response matching inputSchema
+- `input` (any, optional) - Agent response matching inputSchema
+- `teleportTo` (string, optional) - Teleport node ID. Do not provide `input` when teleporting
 
 **Returns:**
 
@@ -113,6 +121,12 @@ step({
   input: { result: "completed", confidence: 9 }
 })
 → { directive: "Next task...", ... }
+```
+
+To jump through a workflow-defined teleport entry:
+
+```json
+step({ processId: "abc-123", teleportTo: "teleport-replan" })
 ```
 
 **Magic Variable - execution_note:**
@@ -196,7 +210,7 @@ Do not mechanically merge JSON. Run WMF, compare all three candidates semantical
 
 ## manage
 
-Unified tool for workflow CRUD operations.
+Unified tool for workflow definition, inspection, node, variable, and sharing operations.
 
 ### Action: create
 
@@ -206,6 +220,11 @@ Creates new workflow from JSON definition with validation.
 
 - `action`: `"create"` (required)
 - `workflow` (object, required) - Workflow definition
+  - `id` (string, optional) - Workflow ID; generated when omitted
+  - `metadata` (object, required) - Name, semantic version, and description
+  - `nodes` (object[], required) - Workflow nodes
+  - `variableRegistry` (object, optional) - Declared global variables
+  - `visibility` (`"public" | "private"`, optional, default: `"private"`)
   - `systemReminder` (string, optional) - Per-workflow system reminder that overrides global setting
 - `overwrite` (boolean, optional) - Allow overwriting existing workflow
 
@@ -239,9 +258,11 @@ Edits existing workflow with partial updates.
 - `workflowId` (string, required) - ID of workflow to edit
 - `changes` (object, required) - Changes to apply
   - `metadata` - Update name, version, description
+  - `variableRegistry` - Replace the declared global variable registry
   - `addNodes` - Array of nodes to add
   - `removeNodes` - Array of node IDs to remove
   - `updateNodes` - Array of objects with nodeId and changes properties
+  - `removeConnections` - Array of node ID and connection-key pairs to remove
   - `systemReminder` - Per-workflow system reminder (set to empty string to clear)
 
 **Returns:**
@@ -261,7 +282,7 @@ manage({
     addNodes: [{ type: "end", id: "new-end", ... }]
   }
 })
-→ { success: true, changesSummary: {...}, validation: {...} }
+→ { success: true, workflowId: "...", changes: { metadataUpdated: true, nodesAdded: 1, ... }, validation: { valid: true } }
 ```
 
 ### Action: get
@@ -304,21 +325,19 @@ Gets workflow structure (metadata + node graph) without full node content. Usefu
 
 - `action`: `"get-structure"` (required)
 - `workflowId` (string, required) - ID of workflow to analyze
-- `graph` (boolean, optional) - Include ASCII flow visualization
-- `detailed` (boolean, optional) - Include directive previews for each node
 
 **Returns:**
 
 - Workflow metadata
 - Node graph with connections
-- ASCII visualization (if graph=true)
-- Node previews (if detailed=true)
+- Node counts by type
+- Visibility and workflow system reminder
 
 **Example:**
 
 ```json
-manage({ action: "get-structure", workflowId: "my-workflow", graph: true, detailed: true })
-→ { metadata: {...}, graph: "start → step-1 → step-2 → end", nodesPreview: [...] }
+manage({ action: "get-structure", workflowId: "my-workflow" })
+→ { metadata: {...}, stats: {...}, graph: [{ nodeId: "start", type: "start", connections: {...} }], visibility: "private" }
 ```
 
 ### Action: get-node
@@ -341,7 +360,7 @@ Gets specific node by ID with full content.
 
 ```json
 manage({ action: "get-node", workflowId: "my-workflow", nodeId: "step-1" })
-→ { id: "step-1", type: "agent-directive", directive: "...", ... }
+→ { success: true, workflowId: "my-workflow", node: { id: "step-1", type: "agent-directive", directive: "...", ... } }
 ```
 
 ### Action: search-nodes
@@ -353,44 +372,46 @@ Searches nodes by text in directive, completionCondition, or ID. Queries contain
 - `action`: `"search-nodes"` (required)
 - `workflowId` (string, required) - Workflow ID
 - `query` (string, required) - Search text or a bounded RE2-compatible regular expression
-- `includeVariables` (boolean, optional) - Search in workflow variables
-- `snippetMode` (boolean, optional) - Return matched text with context only
-- `limit` (number, optional) - Max results
-- `offset` (number, optional) - Pagination offset
 
 **Returns:**
 
 - Array of matching nodes
 - Match context (where text was found)
-- Variable matches (if includeVariables=true)
 
 **Example:**
 
 ```json
-manage({ action: "search-nodes", workflowId: "my-workflow", query: "validation", includeVariables: true, snippetMode: true })
-→ { results: [{ nodeId: "validate-step", matches: ["directive"], snippet: "...run validation..." }] }
+manage({ action: "search-nodes", workflowId: "my-workflow", query: "validation" })
+→ { resultCount: 1, results: [{ nodeId: "validate-step", matchedIn: ["directive"], snippet: "...run validation...", node: {...} }] }
 ```
 
 ### Action: validate
 
-Validates workflow structure and returns errors/warnings.
+Validates a supplied workflow definition and returns errors/warnings without saving it.
 
 **Parameters:**
 
 - `action`: `"validate"` (required)
-- `workflowId` (string, required) - Workflow ID
+- `workflow` (object, required) - Complete workflow definition
 
 **Returns:**
 
 - Validation status (valid/invalid)
+- Error and warning counts
 - Errors array (blocking issues)
 - Warnings array (non-blocking issues)
 
 **Example:**
 
 ```json
-manage({ action: "validate", workflowId: "my-workflow" })
-→ { valid: true, errors: [], warnings: ["Node 'old-step' is unreachable"] }
+manage({
+  action: "validate",
+  workflow: {
+    metadata: { name: "Example", version: "1.0.0", description: "Example workflow" },
+    nodes: [{ id: "start", type: "start", connections: { default: "end" } }, { id: "end", type: "end" }]
+  }
+})
+→ { valid: true, errorCount: 0, warningCount: 0, errors: [], warnings: [] }
 ```
 
 ### Action: list-variables
@@ -455,7 +476,7 @@ Sets or creates a declared global variable in the workflow `variableRegistry`.
 
 ```json
 manage({ action: "set-variable", workflowId: "my-workflow", variableName: "test_directive", variableValue: "Run npm test -- --coverage" })
-→ { variableName: "test_directive", oldValue: "Run npm test", newValue: "Run npm test -- --coverage" }
+→ { variableName: "test_directive", oldValue: { type: "string", description: "Test command", value: "Run npm test" }, newValue: "Run npm test -- --coverage" }
 ```
 
 ### Action: delete-variable
@@ -477,7 +498,7 @@ Deletes a declared global variable from the workflow `variableRegistry`.
 
 ```json
 manage({ action: "delete-variable", workflowId: "my-workflow", variableName: "unused_var" })
-→ { variableName: "unused_var", deletedValue: "old value" }
+→ { variableName: "unused_var", deletedValue: { type: "string", description: "Unused value", value: "old value" } }
 ```
 
 ### Action: diff
@@ -501,7 +522,7 @@ Compares two workflows and shows differences in metadata and nodes.
 
 ```json
 manage({ action: "diff", workflowId: "workflow-v1", compareWorkflowId: "workflow-v2" })
-→ { metadataDiff: { version: { old: "1.0.0", new: "2.0.0" } }, addedNodes: ["new-step"], removedNodes: [], modifiedNodes: [...] }
+→ { identical: false, summary: { metadataChanges: 1, nodesAdded: 1, nodesRemoved: 0, nodesModified: 0, systemReminderChanged: false }, details: { metadata: { version: { old: "1.0.0", new: "2.0.0" } }, addedNodes: ["new-step"] } }
 ```
 
 ### Action: copy
@@ -523,96 +544,177 @@ Creates a copy of existing workflow with new ID.
 
 ```json
 manage({ action: "copy", workflowId: "template-workflow", newName: "My Copy" })
-→ { newWorkflowId: "template-workflow-copy-123", success: true }
+→ { success: true, workflowId: "...", slug: "my-copy", sourceWorkflowId: "template-workflow", visibility: "private" }
 ```
 
-### Action: list-nodes
+### Action: clone-node
 
-Gets compact list of workflow nodes without full content.
+Clones a node within a workflow and inserts the clone after its source.
 
 **Parameters:**
 
-- `action`: `"list-nodes"` (required)
+- `action`: `"clone-node"` (required)
 - `workflowId` (string, required) - Workflow ID
-- `typeFilter` (string, optional) - Filter by node type
-- `includePreview` (boolean, optional) - Include directive preview
-- `previewLength` (number, optional) - Preview character limit
+- `nodeId` (string, required) - Source node ID
+- `newId` (string, optional) - ID for the clone; generated when omitted
 
 **Returns:**
 
-- Node count
-- Array of compact nodes (id, type, connections)
+- Source and cloned node IDs
+- The complete cloned node
 
 **Example:**
 
 ```json
-manage({ action: "list-nodes", workflowId: "my-workflow", typeFilter: "agent-directive" })
-→ { nodeCount: 5, nodes: [{ id: "step-1", type: "agent-directive", connections: ["step-2"] }] }
+manage({ action: "clone-node", workflowId: "my-workflow", nodeId: "step-1", newId: "step-1-copy" })
+→ { sourceNodeId: "step-1", clonedNodeId: "step-1-copy", clonedNode: {...} }
 ```
 
-### Action: get-nodes
+### Action: move-node
 
-Gets multiple nodes by ID array in single request.
+Moves a node to another numeric position in the workflow's node array. Moving does not change authored connections.
 
 **Parameters:**
 
-- `action`: `"get-nodes"` (required)
+- `action`: `"move-node"` (required)
 - `workflowId` (string, required) - Workflow ID
-- `nodeIds` (string[], required) - Array of node IDs
+- `nodeId` (string, required) - Node ID to move
+- `targetIndex` (number, required) - Zero-based target position; values above the last position are clamped
 
 **Returns:**
 
-- Found nodes
-- Not found node IDs
+- Previous and resulting positions
+- Success message
 
 **Example:**
 
 ```json
-manage({ action: "get-nodes", workflowId: "my-workflow", nodeIds: ["step-1", "step-2"] })
-→ { foundCount: 2, nodes: [...], notFound: [] }
+manage({ action: "move-node", workflowId: "my-workflow", nodeId: "step-2", targetIndex: 1 })
+→ { nodeId: "step-2", fromIndex: 3, toIndex: 1 }
 ```
 
-### Action: analyze-variables
+### Action: create-invite
 
-Analyzes variable sources and usages across workflow.
+Creates an owner-authorized invite link for a workflow.
 
 **Parameters:**
 
-- `action`: `"analyze-variables"` (required)
+- `action`: `"create-invite"` (required)
 - `workflowId` (string, required) - Workflow ID
+- `ttlMs` (number, optional) - Invite lifetime in milliseconds (default: 7 days)
 
 **Returns:**
 
-- Variable count
-- Analysis with sources and usages per variable
+- Invite ID, token, expiration, and remaining lifetime
+- Shareable invite URL
 
 **Example:**
 
 ```json
-manage({ action: "analyze-variables", workflowId: "my-workflow" })
-→ { variableCount: 3, analysis: { "task_name": { sources: [...], usages: [...] } } }
+manage({ action: "create-invite", workflowId: "my-workflow", ttlMs: 86400000 })
+→ { workflowId: "...", invite: { id: "invite-1", token: "...", expiresAt: "...", remainingMs: 86399950 }, inviteUrl: "https://.../invites/..." }
 ```
 
-### Action: set-visibility
+### Action: list-access
 
-Changes workflow visibility (public/private).
+Lists users with shared access to an owned workflow.
 
 **Parameters:**
 
-- `action`: `"set-visibility"` (required)
+- `action`: `"list-access"` (required)
 - `workflowId` (string, required) - Workflow ID
-- `visibility` (string, required) - "public" or "private"
+- `limit` (number, optional) - Maximum records to return
+- `offset` (number, optional) - Pagination offset
 
 **Returns:**
 
-- Previous and new visibility
+- Total and returned counts plus `hasMore`
+- Users with identity and grant metadata
 
 **Example:**
 
 ```json
-manage({ action: "set-visibility", workflowId: "my-workflow", visibility: "public" })
-→ { previousVisibility: "private", newVisibility: "public" }
+manage({ action: "list-access", workflowId: "my-workflow", limit: 20, offset: 0 })
+→ { totalCount: 1, returnedCount: 1, hasMore: false, users: [{ userId: "user-1", handle: "alex", ... }] }
 ```
+
+### Action: list-invites
+
+Lists invite links created for an owned workflow.
+
+**Parameters:**
+
+- `action`: `"list-invites"` (required)
+- `workflowId` (string, required) - Workflow ID
+- `activeOnly` (boolean, optional, default: true) - Return only unused active invites
+- `limit` (number, optional) - Maximum records to return
+- `offset` (number, optional) - Pagination offset
+
+**Returns:**
+
+- Active filter, total and returned counts, and `hasMore`
+- Invites with token, creation/expiration, remaining lifetime, and use metadata
+
+**Example:**
+
+```json
+manage({ action: "list-invites", workflowId: "my-workflow", activeOnly: true })
+→ { activeOnly: true, totalCount: 1, returnedCount: 1, hasMore: false, invites: [{ id: "invite-1", ... }] }
+```
+
+### Action: revoke-access
+
+Revokes one user's shared access to an owned workflow.
+
+**Parameters:**
+
+- `action`: `"revoke-access"` (required)
+- `workflowId` (string, required) - Workflow ID
+- `targetUserId` (string, required) - User whose access is revoked
+
+**Returns:**
+
+- Workflow and target user IDs
+- Success message
+
+**Example:**
+
+```json
+manage({ action: "revoke-access", workflowId: "my-workflow", targetUserId: "user-1" })
+→ { workflowId: "...", targetUserId: "user-1", message: "Access revoked for user 'user-1'" }
+```
+
+### Action: revoke-invite
+
+Revokes an invite owned by the current user.
+
+**Parameters:**
+
+- `action`: `"revoke-invite"` (required)
+- `inviteId` (string, required) - Invite ID
+
+**Returns:**
+
+- Revoked invite ID
+- Success message
+
+**Example:**
+
+```json
+manage({ action: "revoke-invite", inviteId: "invite-1" })
+→ { inviteId: "invite-1", message: "Invite 'invite-1' revoked" }
+```
+
+### Failure behavior
+
+`manage` returns an error without applying the requested mutation when required input is missing, a workflow or node cannot be resolved for the current user, or the resulting workflow fails validation. In particular:
+
+- `create` requires a complete valid definition and rejects an existing ID unless `overwrite` is true; `edit` requires non-empty changes and rejects missing/duplicate nodes or an invalid result;
+- stored-workflow reads, variable actions, `diff`, `copy`, `clone-node`, `move-node`, and workflow-scoped sharing actions require an accessible `workflowId`; their action-specific node, variable, comparison, or target IDs are also required;
+- `clone-node` rejects a missing source or duplicate clone ID; `move-node` rejects a missing node, absent or negative `targetIndex`, and any reordered graph that no longer validates;
+- invite/access creation and listing require workflow-owner authority; revoke actions reject a missing target and an invite/access record the current owner cannot revoke.
+
+Errors are returned through the MCP tool response and do not turn a failed action into success.
 
 ---
 
@@ -647,17 +749,24 @@ List active workflow executions for current user.
 **Parameters:**
 
 - `action`: `"executions"` (required)
+- `status` (string[], optional, default: `["running"]`) - Filter by `running`, `waiting`, `completed`, `failed`, or `locked`; legacy statuses are normalized
+- `workflowId` (string, optional) - Filter by workflow ID
+- `search` (string, optional) - Search execution notes
+- `sort` (`"createdAt" | "updatedAt"`, optional, default: `"updatedAt"`) - Sort field
+- `sortOrder` (`"asc" | "desc"`, optional, default: `"desc"`) - Sort order
+- `limit` (number, optional, default: 20) - Results per page (1–100)
+- `offset` (number, optional, default: 0) - Pagination offset
 
 **Returns:**
 
-- Array of active execution objects
-- Status, workflow ID, start time for each
+- `executions` - Execution objects with status, workflow identity, node, note, parent, timestamps, and error count
+- `total` - Total number matching the filters
 
 **Example:**
 
 ```json
-session({ action: "executions" })
-→ [{ executionId: "abc-123", workflowId: "example", status: "waiting", note: "Feature task", ... }]
+session({ action: "executions", status: ["running", "locked"], limit: 20 })
+→ { executions: [{ executionId: "abc-123", workflowId: "example", status: "locked", note: "Feature task", ... }], total: 1 }
 ```
 
 ### Action: execution_context
@@ -738,6 +847,96 @@ Updates execution note for easier identification in execution lists.
 ```json
 session({ action: "update-note", executionId: "abc-123", note: "Step 5: Integration tests" })
 → { success: true, executionId: "abc-123", note: "Step 5: Integration tests" }
+```
+
+---
+
+## lock
+
+Inspects, creates, or unlocks an execution lock. Every action requires an execution owned by the current user.
+
+### Action: status
+
+Returns the active lock, if any.
+
+**Parameters:**
+
+- `action`: `"status"` (required)
+- `executionId` (string, required) - Execution ID
+
+**Returns:**
+
+- `locked` - Whether an active lock exists
+- `lock` - Lock ID, execution/node IDs, reason, status, and timestamps when locked
+
+**Example:**
+
+```json
+lock({ action: "status", executionId: "abc-123" })
+→ { locked: true, lock: { lockId: "lock-1", executionId: "abc-123", reason: "Approval", ... } }
+```
+
+### Action: list
+
+Returns the execution's lock history.
+
+**Parameters:**
+
+- `action`: `"list"` (required)
+- `executionId` (string, required) - Execution ID
+
+**Returns:**
+
+- `locks` - Active and unlocked lock records
+- `total` - Number of records
+
+**Example:**
+
+```json
+lock({ action: "list", executionId: "abc-123" })
+→ { locks: [{ lockId: "lock-1", status: "active", ... }], total: 1 }
+```
+
+### Action: lock
+
+Locks a running execution that does not already have an active lock.
+
+**Parameters:**
+
+- `action`: `"lock"` (required)
+- `executionId` (string, required) - Running execution ID
+- `reason` (string, required) - Reason for the lock
+
+**Returns:**
+
+- New lock ID and `locked: true`
+
+**Example:**
+
+```json
+lock({ action: "lock", executionId: "abc-123", reason: "Awaiting approval" })
+→ { lockId: "lock-1", locked: true }
+```
+
+### Action: unlock
+
+Unlocks the active lock after validating its PIN.
+
+**Parameters:**
+
+- `action`: `"unlock"` (required)
+- `executionId` (string, required) - Execution ID
+- `pin` (string, required) - Lock PIN
+
+**Returns:**
+
+- Lock ID and `unlocked: true`
+
+**Example:**
+
+```json
+lock({ action: "unlock", executionId: "abc-123", pin: "123456" })
+→ { unlocked: true, lockId: "lock-1" }
 ```
 
 ---
@@ -886,8 +1085,10 @@ Create or update a note.
 
 - `action`: `"save"` (required)
 - `key` (string, required) - Note key (1-100 chars, alphanumeric/underscore/hyphen)
-- `value` (string, required) - Note content (max 100 KB)
+- `value` (string, required) - Note content (default max 100 KB)
 - `tags` (string[], optional) - Tags (max 10, each 1-50 chars)
+
+Administrators can change the per-note size, total user storage, and retained-version limits through global settings.
 
 **Returns:**
 
@@ -1005,7 +1206,7 @@ artifacts({
 })
 → {
     uuid: "abc-123",
-    url: "https://{STATIC_DOMAIN}/abc-123.html",
+    url: "https://abc-123.{STATIC_ARTIFACTS_DOMAIN}/",
     name: "analysis-report.html",
     size: 48,
     expiresAt: "2024-02-15T10:00:00Z"
@@ -1072,7 +1273,7 @@ List user's artifacts with pagination.
 
 **Returns:**
 
-- `artifacts` - Array of artifact objects with uuid, url, name, size, mimeType, expiresAt, createdAt, updatedAt
+- `artifacts` - Array of artifact objects with uuid, url, name, size, mimeType, executionId, expiresAt, createdAt, updatedAt
 - `total` - Total count
 
 **Example:**
@@ -1082,10 +1283,11 @@ artifacts({ action: "list", limit: 10 })
 → {
     artifacts: [{
       uuid: "abc-123",
-      url: "https://{STATIC_DOMAIN}/abc-123.html",
+      url: "https://abc-123.{STATIC_ARTIFACTS_DOMAIN}/",
       name: "report.html",
       size: 1024,
       mimeType: "text/html",
+      executionId: null,
       expiresAt: "2024-02-15T10:00:00Z",
       createdAt: "2024-01-15T10:00:00Z",
       updatedAt: "2024-01-15T10:00:00Z"
@@ -1153,10 +1355,14 @@ artifacts({ action: "token", ttlMinutes: 30 })
 
 ### Quotas
 
+Defaults:
+
 - Max file size: 5 MB per artifact
 - Max total storage: 100 MB per user
 - Max artifact count: 50 per user
-- Default TTL: 30 days
+- TTL: 30 days
+
+Administrators can change active quotas globally or per user.
 
 ---
 

--- a/packages/docs/src/content/docs/ru/docs/reference/tools.mdx
+++ b/packages/docs/src/content/docs/ru/docs/reference/tools.mdx
@@ -19,6 +19,12 @@ Moira предоставляет возможности выполнения wor
 
 - `session` - Информация о пользователе, выполнениях или шаге
 - `settings` - Управление настройками пользователя
+- `notes` - Постоянное хранилище заметок с версионированием
+- `lock` - Просмотр, создание и снятие блокировок выполнения
+
+### Контент и артефакты
+
+- `artifacts` - Публикация статических HTML-артефактов с квотами
 
 ### Большие файлы
 
@@ -32,21 +38,27 @@ Moira предоставляет возможности выполнения wor
 
 ## list
 
-Список всех доступных шаблонов workflow со статусом валидации.
+Возвращает доступные текущему пользователю workflow с фильтрацией, сортировкой и пагинацией.
 
-**Параметры:** Нет
+**Параметры:**
+
+- `search` (string, опционально) - Поиск в именах и описаниях workflow
+- `visibility` (`"public" | "private" | "all"`, опционально) - Фильтр видимости
+- `sort` (`"createdAt" | "name"`, опционально, по умолчанию `"createdAt"`) - Поле сортировки
+- `sortOrder` (`"asc" | "desc"`, опционально, по умолчанию `"desc"`) - Порядок сортировки
+- `limit` (number, опционально, по умолчанию 20) - Результатов на странице (1–100)
+- `offset` (number, опционально, по умолчанию 0) - Смещение пагинации
 
 **Возвращает:**
 
-- Массив объектов workflow с метаданными
-- Статус валидации для каждого workflow
-- Пути к файлам и временные метки
+- `workflows` - Сводки workflow с ID, slug, owner handle, именем, версией, описанием, видимостью и временем создания
+- `total` - Общее количество workflow, подходящих под фильтры
 
 **Пример:**
 
 ```json
-list()
-→ [{ id: "example", name: "Example Workflow", valid: true, ... }]
+list({ search: "review", visibility: "public", limit: 20, offset: 0 })
+→ { workflows: [{ id: "moira/review", slug: "review", ownerHandle: "moira", ... }], total: 1 }
 ```
 
 ---
@@ -59,7 +71,7 @@ list()
 
 - `workflowId` (string, обязательный) - ID workflow для выполнения
 - `note` (string, опционально) - Краткая заметка для идентификации выполнения (max 500 chars)
-- `parentExecutionId` (string, опционально) - ID родительского выполнения для связывания workflow
+- `parentExecutionId` (string, обязательный) - ID родительского выполнения. Используйте `"none"` для самостоятельного workflow или UUID родительского выполнения для дочернего workflow
 - `skipTelegramCheck` (boolean, опционально) - Пропустить проверку конфигурации Telegram. Если workflow содержит telegram-notification ноды и Telegram не настроен, start возвращает инструкции по настройке вместо запуска. Установите `true` для пропуска проверки.
 
 **Возвращает:**
@@ -71,17 +83,17 @@ list()
 **Пример:**
 
 ```json
-start({ workflowId: "example", note: "Реализация фичи" })
+start({ workflowId: "example", note: "Реализация фичи", parentExecutionId: "none" })
 → { processId: "abc-123", directive: "...", ... }
 ```
 
 **Связывание родительского выполнения:**
 
 ```json
-start({ workflowId: "sub-workflow", parentExecutionId: "parent-abc-123" })
+start({ workflowId: "sub-workflow", parentExecutionId: "123e4567-e89b-42d3-a456-426614174000" })
 ```
 
-Когда дочерний workflow завершается, система возвращает информацию для продолжения родительского выполнения.
+Замените UUID из примера на `processId` существующего родительского выполнения. После завершения дочернего workflow система возвращает информацию для продолжения этого родителя.
 
 ---
 
@@ -92,7 +104,8 @@ start({ workflowId: "sub-workflow", parentExecutionId: "parent-abc-123" })
 **Параметры:**
 
 - `processId` (string, обязательный) - Process ID из start
-- `input` (any) - Ответ агента, соответствующий inputSchema
+- `input` (any, опционально) - Ответ агента, соответствующий inputSchema
+- `teleportTo` (string, опционально) - ID teleport-ноды. При teleport не передавайте `input`
 
 **Возвращает:**
 
@@ -108,6 +121,12 @@ step({
   input: { result: "completed", confidence: 9 }
 })
 → { directive: "Next task...", ... }
+```
+
+Переход через определённую в workflow teleport-точку:
+
+```json
+step({ processId: "abc-123", teleportTo: "teleport-replan" })
 ```
 
 **Magic Variable - execution_note:**
@@ -191,7 +210,7 @@ reconciliation({
 
 ## manage
 
-Унифицированный инструмент для CRUD операций с workflow.
+Унифицированный инструмент для работы с определением, структурой, нодами, переменными и доступом workflow.
 
 ### Action: create
 
@@ -201,6 +220,11 @@ reconciliation({
 
 - `action`: `"create"` (обязательный)
 - `workflow` (object, обязательный) - Определение workflow
+  - `id` (string, опционально) - ID workflow; генерируется, если не указан
+  - `metadata` (object, обязательный) - Имя, семантическая версия и описание
+  - `nodes` (object[], обязательный) - Ноды workflow
+  - `variableRegistry` (object, опционально) - Объявленные глобальные переменные
+  - `visibility` (`"public" | "private"`, опционально, по умолчанию `"private"`)
   - `systemReminder` (string, опционально) - System reminder для workflow, переопределяет глобальную настройку
 - `overwrite` (boolean, опционально) - Разрешить перезапись существующего
 
@@ -234,9 +258,11 @@ manage({
 - `workflowId` (string, обязательный) - ID workflow для редактирования
 - `changes` (object, обязательный) - Изменения для применения
   - `metadata` - Обновление name, version, description
+  - `variableRegistry` - Замена реестра объявленных глобальных переменных
   - `addNodes` - Массив нод для добавления
   - `removeNodes` - Массив ID нод для удаления
   - `updateNodes` - Массив объектов с nodeId и changes
+  - `removeConnections` - Массив пар ID ноды и ключа удаляемого соединения
   - `systemReminder` - System reminder для workflow (пустая строка для удаления)
 
 **Возвращает:**
@@ -256,7 +282,7 @@ manage({
     addNodes: [{ type: "end", id: "new-end", ... }]
   }
 })
-→ { success: true, changesSummary: {...}, validation: {...} }
+→ { success: true, workflowId: "...", changes: { metadataUpdated: true, nodesAdded: 1, ... }, validation: { valid: true } }
 ```
 
 ### Action: get
@@ -304,13 +330,14 @@ manage({
 
 - Метаданные workflow
 - Граф нод с соединениями
-- Без полного содержимого директив/схем (легкий ответ)
+- Количество нод по типам
+- Видимость и system reminder workflow
 
 **Пример:**
 
 ```json
 manage({ action: "get-structure", workflowId: "my-workflow" })
-→ { metadata: {...}, graph: { nodes: [...], edges: [...] } }
+→ { metadata: {...}, stats: {...}, graph: [{ nodeId: "start", type: "start", connections: {...} }], visibility: "private" }
 ```
 
 ### Action: get-node
@@ -333,7 +360,7 @@ manage({ action: "get-structure", workflowId: "my-workflow" })
 
 ```json
 manage({ action: "get-node", workflowId: "my-workflow", nodeId: "step-1" })
-→ { id: "step-1", type: "agent-directive", directive: "...", ... }
+→ { success: true, workflowId: "my-workflow", node: { id: "step-1", type: "agent-directive", directive: "...", ... } }
 ```
 
 ### Action: search-nodes
@@ -345,8 +372,6 @@ manage({ action: "get-node", workflowId: "my-workflow", nodeId: "step-1" })
 - `action`: `"search-nodes"` (обязательный)
 - `workflowId` (string, обязательный) - ID workflow
 - `query` (string, обязательный) - Текст поиска или ограниченное RE2-совместимое регулярное выражение
-- `limit` (number, опционально) - Максимум результатов
-- `offset` (number, опционально) - Смещение для пагинации
 
 **Возвращает:**
 
@@ -357,29 +382,36 @@ manage({ action: "get-node", workflowId: "my-workflow", nodeId: "step-1" })
 
 ```json
 manage({ action: "search-nodes", workflowId: "my-workflow", query: "validation" })
-→ { results: [{ nodeId: "validate-step", matches: ["directive"] }] }
+→ { resultCount: 1, results: [{ nodeId: "validate-step", matchedIn: ["directive"], snippet: "...run validation...", node: {...} }] }
 ```
 
 ### Action: validate
 
-Валидирует структуру workflow и возвращает ошибки/предупреждения.
+Валидирует переданное определение workflow без сохранения и возвращает ошибки/предупреждения.
 
 **Параметры:**
 
 - `action`: `"validate"` (обязательный)
-- `workflowId` (string, обязательный) - ID workflow
+- `workflow` (object, обязательный) - Полное определение workflow
 
 **Возвращает:**
 
 - Статус валидации (valid/invalid)
+- Количество ошибок и предупреждений
 - Массив ошибок (блокирующие проблемы)
 - Массив предупреждений (неблокирующие проблемы)
 
 **Пример:**
 
 ```json
-manage({ action: "validate", workflowId: "my-workflow" })
-→ { valid: true, errors: [], warnings: ["Node 'old-step' is unreachable"] }
+manage({
+  action: "validate",
+  workflow: {
+    metadata: { name: "Example", version: "1.0.0", description: "Example workflow" },
+    nodes: [{ id: "start", type: "start", connections: { default: "end" } }, { id: "end", type: "end" }]
+  }
+})
+→ { valid: true, errorCount: 0, warningCount: 0, errors: [], warnings: [] }
 ```
 
 ### Action: list-variables
@@ -444,7 +476,7 @@ manage({ action: "get-variable", workflowId: "my-workflow", variableName: "test_
 
 ```json
 manage({ action: "set-variable", workflowId: "my-workflow", variableName: "test_directive", variableValue: "Run npm test -- --coverage" })
-→ { variableName: "test_directive", oldValue: "Run npm test", newValue: "Run npm test -- --coverage" }
+→ { variableName: "test_directive", oldValue: { type: "string", description: "Test command", value: "Run npm test" }, newValue: "Run npm test -- --coverage" }
 ```
 
 ### Action: delete-variable
@@ -466,7 +498,7 @@ manage({ action: "set-variable", workflowId: "my-workflow", variableName: "test_
 
 ```json
 manage({ action: "delete-variable", workflowId: "my-workflow", variableName: "unused_var" })
-→ { variableName: "unused_var", deletedValue: "old value" }
+→ { variableName: "unused_var", deletedValue: { type: "string", description: "Unused value", value: "old value" } }
 ```
 
 ### Action: diff
@@ -490,8 +522,199 @@ manage({ action: "delete-variable", workflowId: "my-workflow", variableName: "un
 
 ```json
 manage({ action: "diff", workflowId: "workflow-v1", compareWorkflowId: "workflow-v2" })
-→ { metadataDiff: { version: { old: "1.0.0", new: "2.0.0" } }, addedNodes: ["new-step"], removedNodes: [], modifiedNodes: [...] }
+→ { identical: false, summary: { metadataChanges: 1, nodesAdded: 1, nodesRemoved: 0, nodesModified: 0, systemReminderChanged: false }, details: { metadata: { version: { old: "1.0.0", new: "2.0.0" } }, addedNodes: ["new-step"] } }
 ```
+
+### Action: copy
+
+Создаёт копию существующего workflow с новым ID.
+
+**Параметры:**
+
+- `action`: `"copy"` (обязательный)
+- `workflowId` (string, обязательный) - ID исходного workflow
+- `newName` (string, опционально) - Имя копии
+
+**Возвращает:**
+
+- ID нового workflow
+- Статус успеха
+
+**Пример:**
+
+```json
+manage({ action: "copy", workflowId: "template-workflow", newName: "Моя копия" })
+→ { success: true, workflowId: "...", slug: "my-copy", sourceWorkflowId: "template-workflow", visibility: "private" }
+```
+
+### Action: clone-node
+
+Клонирует ноду внутри workflow и вставляет копию после исходной ноды.
+
+**Параметры:**
+
+- `action`: `"clone-node"` (обязательный)
+- `workflowId` (string, обязательный) - ID workflow
+- `nodeId` (string, обязательный) - ID исходной ноды
+- `newId` (string, опционально) - ID копии; генерируется, если не указан
+
+**Возвращает:**
+
+- ID исходной и клонированной ноды
+- Полную клонированную ноду
+
+**Пример:**
+
+```json
+manage({ action: "clone-node", workflowId: "my-workflow", nodeId: "step-1", newId: "step-1-copy" })
+→ { sourceNodeId: "step-1", clonedNodeId: "step-1-copy", clonedNode: {...} }
+```
+
+### Action: move-node
+
+Перемещает ноду на другую числовую позицию в массиве нод workflow. Перемещение не меняет заданные соединения.
+
+**Параметры:**
+
+- `action`: `"move-node"` (обязательный)
+- `workflowId` (string, обязательный) - ID workflow
+- `nodeId` (string, обязательный) - ID перемещаемой ноды
+- `targetIndex` (number, обязательный) - Целевая позиция с нуля; значение после последней позиции ограничивается последней позицией
+
+**Возвращает:**
+
+- Исходную и итоговую позиции
+- Сообщение об успехе
+
+**Пример:**
+
+```json
+manage({ action: "move-node", workflowId: "my-workflow", nodeId: "step-2", targetIndex: 1 })
+→ { nodeId: "step-2", fromIndex: 3, toIndex: 1 }
+```
+
+### Action: create-invite
+
+Создаёт invite-ссылку для workflow после проверки владельца.
+
+**Параметры:**
+
+- `action`: `"create-invite"` (обязательный)
+- `workflowId` (string, обязательный) - ID workflow
+- `ttlMs` (number, опционально) - Срок действия invite в миллисекундах (по умолчанию 7 дней)
+
+**Возвращает:**
+
+- ID, токен, время истечения и оставшийся срок invite
+- URL invite для передачи другому пользователю
+
+**Пример:**
+
+```json
+manage({ action: "create-invite", workflowId: "my-workflow", ttlMs: 86400000 })
+→ { workflowId: "...", invite: { id: "invite-1", token: "...", expiresAt: "...", remainingMs: 86399950 }, inviteUrl: "https://.../invites/..." }
+```
+
+### Action: list-access
+
+Возвращает пользователей с выданным доступом к workflow текущего владельца.
+
+**Параметры:**
+
+- `action`: `"list-access"` (обязательный)
+- `workflowId` (string, обязательный) - ID workflow
+- `limit` (number, опционально) - Максимальное количество записей
+- `offset` (number, опционально) - Смещение пагинации
+
+**Возвращает:**
+
+- Общее и возвращённое количество плюс `hasMore`
+- Пользователей с идентификаторами и данными о выдаче доступа
+
+**Пример:**
+
+```json
+manage({ action: "list-access", workflowId: "my-workflow", limit: 20, offset: 0 })
+→ { totalCount: 1, returnedCount: 1, hasMore: false, users: [{ userId: "user-1", handle: "alex", ... }] }
+```
+
+### Action: list-invites
+
+Возвращает invite-ссылки, созданные для workflow текущего владельца.
+
+**Параметры:**
+
+- `action`: `"list-invites"` (обязательный)
+- `workflowId` (string, обязательный) - ID workflow
+- `activeOnly` (boolean, опционально, по умолчанию true) - Возвращать только активные неиспользованные invite
+- `limit` (number, опционально) - Максимальное количество записей
+- `offset` (number, опционально) - Смещение пагинации
+
+**Возвращает:**
+
+- Активный фильтр, общее и возвращённое количество и `hasMore`
+- Invite с токеном, временем создания/истечения, оставшимся сроком и данными использования
+
+**Пример:**
+
+```json
+manage({ action: "list-invites", workflowId: "my-workflow", activeOnly: true })
+→ { activeOnly: true, totalCount: 1, returnedCount: 1, hasMore: false, invites: [{ id: "invite-1", ... }] }
+```
+
+### Action: revoke-access
+
+Отзывает доступ одного пользователя к workflow текущего владельца.
+
+**Параметры:**
+
+- `action`: `"revoke-access"` (обязательный)
+- `workflowId` (string, обязательный) - ID workflow
+- `targetUserId` (string, обязательный) - Пользователь, у которого отзывается доступ
+
+**Возвращает:**
+
+- ID workflow и пользователя
+- Сообщение об успехе
+
+**Пример:**
+
+```json
+manage({ action: "revoke-access", workflowId: "my-workflow", targetUserId: "user-1" })
+→ { workflowId: "...", targetUserId: "user-1", message: "Access revoked for user 'user-1'" }
+```
+
+### Action: revoke-invite
+
+Отзывает invite текущего владельца.
+
+**Параметры:**
+
+- `action`: `"revoke-invite"` (обязательный)
+- `inviteId` (string, обязательный) - ID invite
+
+**Возвращает:**
+
+- ID отозванного invite
+- Сообщение об успехе
+
+**Пример:**
+
+```json
+manage({ action: "revoke-invite", inviteId: "invite-1" })
+→ { inviteId: "invite-1", message: "Invite 'invite-1' revoked" }
+```
+
+### Ошибки
+
+`manage` возвращает ошибку без применения запрошенного изменения, если отсутствует обязательный ввод, workflow или нода недоступны текущему пользователю либо итоговый workflow не проходит валидацию. В частности:
+
+- `create` требует полное корректное определение и отклоняет существующий ID без `overwrite: true`; `edit` требует непустые изменения и отклоняет отсутствующие/дублирующиеся ноды или некорректный результат;
+- чтение сохранённых workflow, операции с переменными, `diff`, `copy`, `clone-node`, `move-node` и привязанные к workflow операции доступа требуют доступный `workflowId`; обязательны также ID ноды, переменной, сравнения или цели конкретного действия;
+- `clone-node` отклоняет отсутствующий источник и занятый ID копии; `move-node` отклоняет отсутствующую ноду, отсутствующий или отрицательный `targetIndex` и перестановку, после которой граф не проходит валидацию;
+- создание и просмотр invite/access требуют права владельца workflow; revoke-действия отклоняют отсутствующую цель и invite/access, который текущий владелец не может отозвать.
+
+Ошибка возвращается в ответе MCP-инструмента и не превращает неуспешное действие в успех.
 
 ---
 
@@ -526,17 +749,24 @@ session({ action: "user" })
 **Параметры:**
 
 - `action`: `"executions"` (обязательный)
+- `status` (string[], опционально, по умолчанию `["running"]`) - Фильтр по `running`, `waiting`, `completed`, `failed` или `locked`; устаревшие статусы нормализуются
+- `workflowId` (string, опционально) - Фильтр по ID workflow
+- `search` (string, опционально) - Поиск в заметках выполнения
+- `sort` (`"createdAt" | "updatedAt"`, опционально, по умолчанию `"updatedAt"`) - Поле сортировки
+- `sortOrder` (`"asc" | "desc"`, опционально, по умолчанию `"desc"`) - Порядок сортировки
+- `limit` (number, опционально, по умолчанию 20) - Результатов на странице (1–100)
+- `offset` (number, опционально, по умолчанию 0) - Смещение пагинации
 
 **Возвращает:**
 
-- Массив объектов активных выполнений
-- Статус, workflowId, время старта для каждого
+- `executions` - Выполнения со статусом, идентификатором workflow, нодой, заметкой, родителем, временными метками и количеством ошибок
+- `total` - Общее количество выполнений, подходящих под фильтры
 
 **Пример:**
 
 ```json
-session({ action: "executions" })
-→ [{ executionId: "abc-123", workflowId: "example", status: "waiting", note: "Реализация фичи", ... }]
+session({ action: "executions", status: ["running", "locked"], limit: 20 })
+→ { executions: [{ executionId: "abc-123", workflowId: "example", status: "locked", note: "Реализация фичи", ... }], total: 1 }
 ```
 
 ### Action: execution_context
@@ -622,6 +852,96 @@ session({ action: "update-note", executionId: "abc-123", note: "Шаг 5: Инт
 
 ---
 
+## lock
+
+Показывает, создаёт или снимает блокировку выполнения. Для каждого действия выполнение должно принадлежать текущему пользователю.
+
+### Action: status
+
+Возвращает активную блокировку, если она есть.
+
+**Параметры:**
+
+- `action`: `"status"` (обязательный)
+- `executionId` (string, обязательный) - ID выполнения
+
+**Возвращает:**
+
+- `locked` - Наличие активной блокировки
+- `lock` - ID блокировки, ID выполнения и ноды, причину, статус и временные метки
+
+**Пример:**
+
+```json
+lock({ action: "status", executionId: "abc-123" })
+→ { locked: true, lock: { lockId: "lock-1", executionId: "abc-123", reason: "Согласование", ... } }
+```
+
+### Action: list
+
+Возвращает историю блокировок выполнения.
+
+**Параметры:**
+
+- `action`: `"list"` (обязательный)
+- `executionId` (string, обязательный) - ID выполнения
+
+**Возвращает:**
+
+- `locks` - Активные и снятые блокировки
+- `total` - Количество записей
+
+**Пример:**
+
+```json
+lock({ action: "list", executionId: "abc-123" })
+→ { locks: [{ lockId: "lock-1", status: "active", ... }], total: 1 }
+```
+
+### Action: lock
+
+Блокирует выполняющийся процесс без другой активной блокировки.
+
+**Параметры:**
+
+- `action`: `"lock"` (обязательный)
+- `executionId` (string, обязательный) - ID выполняющегося процесса
+- `reason` (string, обязательный) - Причина блокировки
+
+**Возвращает:**
+
+- ID новой блокировки и `locked: true`
+
+**Пример:**
+
+```json
+lock({ action: "lock", executionId: "abc-123", reason: "Ожидание согласования" })
+→ { lockId: "lock-1", locked: true }
+```
+
+### Action: unlock
+
+Снимает активную блокировку после проверки PIN.
+
+**Параметры:**
+
+- `action`: `"unlock"` (обязательный)
+- `executionId` (string, обязательный) - ID выполнения
+- `pin` (string, обязательный) - PIN блокировки
+
+**Возвращает:**
+
+- ID блокировки и `unlocked: true`
+
+**Пример:**
+
+```json
+lock({ action: "unlock", executionId: "abc-123", pin: "123456" })
+→ { unlocked: true, lockId: "lock-1" }
+```
+
+---
+
 ## settings
 
 Унифицированный инструмент для управления настройками пользователя.
@@ -692,6 +1012,353 @@ settings({
 settings({ action: "list", category: "telegram" })
 → [{ key: "telegram.bot_token", description: "Your Telegram bot token" }]
 ```
+
+---
+
+## notes
+
+Постоянное пользовательское хранилище заметок с версиями и тегами. Заметки позволяют сохранять настройки, результаты анализа и другие данные между выполнениями workflow.
+
+### Action: list
+
+Возвращает заметки с необязательной фильтрацией по тегу или ключу.
+
+**Параметры:**
+
+- `action`: `"list"` (обязательный)
+- `tag` (string, опционально) - Фильтр по тегу
+- `keySearch` (string, опционально) - Поиск по ключу
+- `limit` (number, опционально) - Максимум заметок (1–100, по умолчанию 50)
+- `offset` (number, опционально) - Смещение пагинации
+
+**Возвращает:**
+
+- Массив заметок с ID, ключом, версией, тегами, размером, превью и временными метками
+- Общее количество
+- Все уникальные теги
+
+**Пример:**
+
+```json
+notes({ action: "list", tag: "preferences" })
+→ {
+    notes: [{ id: "abc", key: "commit-style", version: 2, tags: ["preferences"], ... }],
+    total: 1,
+    allTags: ["preferences", "analysis"]
+  }
+```
+
+### Action: get
+
+Возвращает содержимое заметки по ключу.
+
+**Параметры:**
+
+- `action`: `"get"` (обязательный)
+- `key` (string, обязательный) - Ключ заметки
+- `version` (number, опционально) - Номер конкретной версии
+
+**Возвращает:**
+
+- Полную заметку со значением, версией, тегами, размером и временными метками
+
+**Пример:**
+
+```json
+notes({ action: "get", key: "commit-style" })
+→ {
+    id: "abc",
+    key: "commit-style",
+    value: "conventional",
+    version: 2,
+    tags: ["preferences"],
+    size: 12,
+    createdAt: "2024-01-15T10:00:00Z",
+    updatedAt: "2024-01-15T11:00:00Z"
+  }
+```
+
+### Action: save
+
+Создаёт или обновляет заметку.
+
+**Параметры:**
+
+- `action`: `"save"` (обязательный)
+- `key` (string, обязательный) - Ключ заметки (1–100 символов: буквы, цифры, `_` и `-`)
+- `value` (string, обязательный) - Содержимое заметки (по умолчанию максимум 100 КБ)
+- `tags` (string[], опционально) - До 10 тегов длиной 1–50 символов
+
+Лимиты размера заметки, общего пользовательского хранилища и количества версий могут быть изменены глобальными настройками администратора.
+
+**Возвращает:**
+
+- ID, ключ, версию и признак создания новой заметки
+
+**Пример:**
+
+```json
+notes({
+  action: "save",
+  key: "commit-style",
+  value: "conventional",
+  tags: ["preferences"]
+})
+→ { id: "abc", key: "commit-style", version: 1, created: true }
+```
+
+### Action: delete
+
+Мягко удаляет заметку.
+
+**Параметры:**
+
+- `action`: `"delete"` (обязательный)
+- `key` (string, обязательный) - Ключ заметки
+
+**Возвращает:**
+
+- Статус удаления и ключ
+
+**Пример:**
+
+```json
+notes({ action: "delete", key: "old-note" })
+→ { deleted: true, key: "old-note" }
+```
+
+### Action: history
+
+Возвращает историю версий заметки.
+
+**Параметры:**
+
+- `action`: `"history"` (обязательный)
+- `key` (string, обязательный) - Ключ заметки
+
+**Возвращает:**
+
+- Массив версий с номером, размером, превью и временной меткой
+
+**Пример:**
+
+```json
+notes({ action: "history", key: "commit-style" })
+→ [
+    { version: 2, size: 12, preview: "conventional", createdAt: "2024-01-15T11:00:00Z" },
+    { version: 1, size: 8, preview: "standard", createdAt: "2024-01-15T10:00:00Z" }
+  ]
+```
+
+### Action: stats
+
+Возвращает использование пользовательского хранилища заметок.
+
+**Параметры:**
+
+- `action`: `"stats"` (обязательный)
+
+**Возвращает:**
+
+- Количество заметок
+- Общий занятый размер
+- Действующий лимит
+- Процент использования
+
+**Пример:**
+
+```json
+notes({ action: "stats" })
+→ { totalNotes: 5, totalSize: 2048, limit: 1048576, usedPercent: 0.2 }
+```
+
+---
+
+## artifacts
+
+Публикует статические HTML-артефакты с квотами и возвращает публичные URL. Инструмент предназначен для отчётов, визуализаций и других автономных HTML-документов.
+
+### Action: upload
+
+Создаёт HTML-артефакт и возвращает его публичный URL.
+
+**Параметры:**
+
+- `action`: `"upload"` (обязательный)
+- `name` (string, обязательный) - Имя артефакта, например `report.html`
+- `content` (string, обязательный) - HTML-содержимое
+- `executionId` (string, опционально) - Выполнение workflow, с которым связан артефакт
+
+**Возвращает:**
+
+- `uuid` - Идентификатор артефакта
+- `url` - Публичный URL
+- `name` - Имя
+- `size` - Размер в байтах
+- `expiresAt` - Время истечения в ISO 8601
+
+**Пример:**
+
+```json
+artifacts({
+  action: "upload",
+  name: "analysis-report.html",
+  content: "<html><body><h1>Report</h1></body></html>"
+})
+→ {
+    uuid: "abc-123",
+    url: "https://abc-123.static.example.com/",
+    name: "analysis-report.html",
+    size: 48,
+    expiresAt: "2024-02-15T10:00:00Z"
+  }
+```
+
+### Action: update
+
+Обновляет существующий артефакт.
+
+**Параметры:**
+
+- `action`: `"update"` (обязательный)
+- `uuid` (string, обязательный) - UUID артефакта
+- `content` (string, обязательный) - Новое HTML-содержимое
+- `name` (string, опционально) - Новое имя
+
+**Возвращает:**
+
+- UUID и статус обновления
+
+**Пример:**
+
+```json
+artifacts({
+  action: "update",
+  uuid: "abc-123",
+  content: "<html><body><h1>Обновлённый отчёт</h1></body></html>"
+})
+→ { uuid: "abc-123", updated: true }
+```
+
+### Action: delete
+
+Мягко удаляет артефакт.
+
+**Параметры:**
+
+- `action`: `"delete"` (обязательный)
+- `uuid` (string, обязательный) - UUID артефакта
+
+**Возвращает:**
+
+- UUID и статус удаления
+
+**Пример:**
+
+```json
+artifacts({ action: "delete", uuid: "abc-123" })
+→ { uuid: "abc-123", deleted: true }
+```
+
+### Action: list
+
+Возвращает пользовательские артефакты с пагинацией.
+
+**Параметры:**
+
+- `action`: `"list"` (обязательный)
+- `limit` (number, опционально) - Максимум артефактов (1–100, по умолчанию 50)
+- `offset` (number, опционально) - Смещение пагинации
+
+**Возвращает:**
+
+- Массив артефактов с UUID, URL, именем, размером, MIME-типом, выполнением, сроком действия и временными метками
+- Общее количество
+
+**Пример:**
+
+```json
+artifacts({ action: "list", limit: 10 })
+→ {
+    artifacts: [{
+      uuid: "abc-123",
+      url: "https://abc-123.static.example.com/",
+      name: "report.html",
+      size: 1024,
+      mimeType: "text/html",
+      executionId: null,
+      expiresAt: "2024-02-15T10:00:00Z",
+      createdAt: "2024-01-15T10:00:00Z",
+      updatedAt: "2024-01-15T10:00:00Z"
+    }],
+    total: 1
+  }
+```
+
+### Action: stats
+
+Возвращает использование квот артефактов.
+
+**Параметры:**
+
+- `action`: `"stats"` (обязательный)
+
+**Возвращает:**
+
+- Количество и общий размер артефактов
+- Действующие лимиты размера и количества
+- Проценты использования хранилища и количества
+
+**Пример:**
+
+```json
+artifacts({ action: "stats" })
+→ {
+    totalArtifacts: 5,
+    totalSize: 51200,
+    storageLimit: 104857600,
+    countLimit: 50,
+    storageUsedPercent: 0.05,
+    countUsedPercent: 10
+  }
+```
+
+### Action: token
+
+Создаёт одноразовый токен для загрузки через HTTP API.
+
+**Параметры:**
+
+- `action`: `"token"` (обязательный)
+- `ttlMinutes` (number, опционально) - Срок действия токена в минутах (1–1440, по умолчанию 60)
+
+**Возвращает:**
+
+- Токен
+- Время истечения в ISO 8601
+- URL загрузки
+
+**Пример:**
+
+```json
+artifacts({ action: "token", ttlMinutes: 30 })
+→ {
+    token: "xyz-789",
+    expiresAt: "2024-01-15T10:30:00Z",
+    uploadUrl: "https://{MOIRA_HOST}/api/public/artifacts/upload/xyz-789"
+  }
+```
+
+### Квоты
+
+Значения по умолчанию:
+
+- Максимальный размер файла: 5 МБ
+- Общее хранилище пользователя: 100 МБ
+- Количество артефактов пользователя: 50
+- Срок действия: 30 дней
+
+Администратор может изменить действующие квоты глобально или для пользователя.
 
 ---
 


### PR DESCRIPTION
## Summary

- describe active Dependabot and Security Checks behavior in contributor/security docs
- align EN/RU MCP tools references with the effective registered schemas
- document observable response envelopes and representative failure behavior without exposing internal-only handler actions

Closes #118

## Testing

- Command: `npm run test:unit -- --file tests/unit/github/security-automation-contract.test.cjs`
- Outcome: 5 passed, 0 failed
- Command: `npm run test:unit -- --file tests/unit/mcp-server/get-help-mdx.test.ts`
- Outcome: 26 passed, 0 failed
- Command: environment-complete `npx astro build` under Node 24.18.0
- Outcome: 132 EN/RU pages built; generated tools pages opened in Chromium and inspected
- Command: `npx prettier --check CONTRIBUTING.md SECURITY.md packages/docs/src/content/docs/docs/reference/tools.mdx packages/docs/src/content/docs/ru/docs/reference/tools.mdx`
- Outcome: passed; `git diff --check` passed
