### PR TITLE
fix(deps): exclude unusable published versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,15 @@ updates:
         update-types:
           - version-update:semver-minor
           - version-update:semver-patch
+    ignore:
+      - dependency-name: "@daveyplate/better-auth-ui"
+        versions: ["3.4.0"]
+      - dependency-name: "@hookform/resolvers"
+        versions: ["5.9.1"]
+      - dependency-name: better-auth
+        versions: ["1.7.1"]
+      - dependency-name: "@xyflow/react"
+        versions: ["12.11.4"]
     groups:
       production-dependencies:
         applies-to: version-updates

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -77,6 +77,12 @@ the exact installed versions of native/tooling packages. A version change must a
 the new exact entry only after reviewing the package script; stale entries are
 removed in the same dependency refresh.
 
+Dependabot ignores only the exact currently unusable releases named in
+`.github/dependabot.yml`: Better Auth 1.7.1, Auth UI 3.4.0, Resolvers 5.9.1, and
+Xyflow 12.11.4. Successor versions remain eligible, as do security updates that
+resolve to another version. Remove an ignore entry in the same change that proves
+its replacement passes the corresponding removal trigger above.
+
 ### Docker Build Configuration
 
 **Build IDs for cache isolation:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "express-rate-limit": "^8.2.1",
         "geoip-lite": "^2.0.3",
         "helmet": "^7.0.0",
-        "lucide-react": "^0.544.0",
+        "lucide-react": "^0.577.0",
         "morgan": "^1.10.1",
         "postcss": "^8.5.6",
         "react": "^18.2.0",
@@ -21095,9 +21095,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.544.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.544.0.tgz",
-      "integrity": "sha512-t5tS44bqd825zAW45UQxpG2CvcC4urOwn2TrwSH8u+MjeE+1NnWl6QqeQ/6NdjMqdOygyiT9p3Ev0p1NJykxjw==",
+      "version": "0.577.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
+      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "express-rate-limit": "^8.2.1",
     "geoip-lite": "^2.0.3",
     "helmet": "^7.0.0",
-    "lucide-react": "^0.544.0",
+    "lucide-react": "^0.577.0",
     "morgan": "^1.10.1",
     "postcss": "^8.5.6",
     "react": "^18.2.0",

--- a/tests/unit/github/security-automation-contract.test.cjs
+++ b/tests/unit/github/security-automation-contract.test.cjs
@@ -46,6 +46,7 @@ describe("security automation contract", () => {
       "rebase-strategy",
       "commit-message",
       "allow",
+      "ignore",
       "groups",
     ]);
     expect(npm).toMatchObject({
@@ -66,6 +67,12 @@ describe("security automation contract", () => {
         "dependency-type": "development",
         "update-types": ["version-update:semver-minor", "version-update:semver-patch"],
       },
+    ]);
+    expect(npm.ignore).toEqual([
+      { "dependency-name": "@daveyplate/better-auth-ui", versions: ["3.4.0"] },
+      { "dependency-name": "@hookform/resolvers", versions: ["5.9.1"] },
+      { "dependency-name": "better-auth", versions: ["1.7.1"] },
+      { "dependency-name": "@xyflow/react", versions: ["12.11.4"] },
     ]);
     expect(npm.groups).toEqual({
       "production-dependencies": {


### PR DESCRIPTION
## Summary

- update Lucide to the latest applicable 0.x release with owner-only authorship
- ignore only four exact published versions proven incompatible by resolver, compile, or runtime evidence
- keep successor and security versions eligible while preventing repeated mixed red bot PRs

Closes #122

## Testing

- Command: npm install; npm audit; npm run fix; npm run test:unit -- --file tests/unit/github/security-automation-contract.test.cjs
- Outcome: install and audit passed with zero vulnerabilities; policy contract passed 5/5; full dependency baseline and Action follow-up passed their complete CI/Docker gates