### PR TITLE
fix(deps): bound incompatible auth minors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,11 +29,11 @@ updates:
           - version-update:semver-patch
     ignore:
       - dependency-name: "@daveyplate/better-auth-ui"
-        versions: ["3.4.0"]
+        update-types: ["version-update:semver-minor"]
       - dependency-name: "@hookform/resolvers"
-        versions: ["5.9.1"]
+        update-types: ["version-update:semver-minor"]
       - dependency-name: better-auth
-        versions: ["1.7.1"]
+        update-types: ["version-update:semver-minor"]
       - dependency-name: "@xyflow/react"
         versions: ["12.11.4"]
     groups:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -77,11 +77,12 @@ the exact installed versions of native/tooling packages. A version change must a
 the new exact entry only after reviewing the package script; stale entries are
 removed in the same dependency refresh.
 
-Dependabot ignores only the exact currently unusable releases named in
-`.github/dependabot.yml`: Better Auth 1.7.1, Auth UI 3.4.0, Resolvers 5.9.1, and
-Xyflow 12.11.4. Successor versions remain eligible, as do security updates that
-resolve to another version. Remove an ignore entry in the same change that proves
-its replacement passes the corresponding removal trigger above.
+Dependabot ignores scheduled minor version updates for the currently incompatible
+Better Auth/Auth UI/Resolvers stack and only the exact broken Xyflow 12.11.4
+release. Patch updates outside those exclusions remain eligible. Dependabot's
+`update-types` restrictions apply to version updates, not security updates. Remove
+an ignore entry in the same change that proves its replacement passes the
+corresponding removal trigger above.
 
 ### Docker Build Configuration
 

--- a/tests/unit/github/security-automation-contract.test.cjs
+++ b/tests/unit/github/security-automation-contract.test.cjs
@@ -69,9 +69,18 @@ describe("security automation contract", () => {
       },
     ]);
     expect(npm.ignore).toEqual([
-      { "dependency-name": "@daveyplate/better-auth-ui", versions: ["3.4.0"] },
-      { "dependency-name": "@hookform/resolvers", versions: ["5.9.1"] },
-      { "dependency-name": "better-auth", versions: ["1.7.1"] },
+      {
+        "dependency-name": "@daveyplate/better-auth-ui",
+        "update-types": ["version-update:semver-minor"],
+      },
+      {
+        "dependency-name": "@hookform/resolvers",
+        "update-types": ["version-update:semver-minor"],
+      },
+      {
+        "dependency-name": "better-auth",
+        "update-types": ["version-update:semver-minor"],
+      },
       { "dependency-name": "@xyflow/react", versions: ["12.11.4"] },
     ]);
     expect(npm.groups).toEqual({


### PR DESCRIPTION
## Summary

- express the confirmed Better Auth/Auth UI/Resolvers incompatibility at the semver-minor class instead of chasing individual patches
- retain patch and security update eligibility while suppressing repeated unusable version PRs
- preserve the exact Xyflow 12.11.4 exclusion separately

Closes #122

## Testing

- Command: npm run fix; npm run test:unit -- --file tests/unit/github/security-automation-contract.test.cjs
- Outcome: formatting/lint completed with zero errors and the full Dependabot config/documentation contract passed 5/5