### PR TITLE
fix(auth): resolve OAuth pages through the Web UI base path

### DIFF
--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -281,7 +281,10 @@ MCP clients use OAuth 2.1 authorization flow:
 3. Fetches `/.well-known/oauth-protected-resource`
 4. Fetches `/.well-known/oauth-authorization-server`
 5. Opens `authorization_endpoint` in browser
-6. User logs in at `/oauth/authorize`
+6. User logs in at `/oauth/authorize`, or `/app/oauth/authorize` in a build with
+   `APP_BASE_PATH=/app` — the login and consent pages follow the Web UI base path.
+   Clients that open the bare `authorization_endpoint` are redirected to the
+   prefixed page.
 7. User sees consent screen with requested permissions
 8. User clicks Allow to grant access
 9. Consent saved to database for future auto-approval

--- a/packages/shared/src/auth/better-auth-config.ts
+++ b/packages/shared/src/auth/better-auth-config.ts
@@ -18,6 +18,7 @@ import { user, oauthAccessToken } from "../database/schema.js";
 import { and, eq } from "drizzle-orm";
 import { getBaseUrl, getAuthUrl, getMcpUrl, isProduction } from "../config/urls.js";
 import {
+  getAppPrefix,
   getBetterAuthSecret,
   getGitHubClientId,
   getGitHubClientSecret,
@@ -226,6 +227,32 @@ function isValidLoadTestRequest(
   }
 }
 
+// The Web UI serves the OAuth authorize/consent pages under the deployment's
+// base-path prefix (getAppPrefix(): "" for self-host root, "/app" for our
+// hosted deploy). Better Auth's mcp/oidc-provider plugin interpolates
+// loginPage/consentPage directly into its own redirects, so these must be
+// prefix-aware here rather than relying on the web backend's compensating
+// GET /oauth/authorize redirect, which only covers requests that hit that
+// exact bare-path route.
+//
+// Note: mcp() overwrites oidcConfig.loginPage with the top-level loginPage,
+// so only the top-level loginPage and oidcConfig.consentPage reach a redirect.
+// Both are set consistently so neither the live nor the shadowed value can
+// drift back to an unprefixed path.
+export function buildMcpPluginOptions() {
+  const appPrefix = getAppPrefix();
+  const loginPage = `${appPrefix}/oauth/authorize`;
+
+  return {
+    loginPage,
+    resource: getMcpUrl(),
+    oidcConfig: {
+      loginPage,
+      consentPage: `${appPrefix}/oauth/consent`,
+    },
+  };
+}
+
 // Base configuration (shared between services)
 // Note: baseURL must include basePath for correct URL generation in emails
 const baseConfig = {
@@ -376,16 +403,7 @@ const baseConfig = {
     },
   },
 
-  plugins: [
-    mcp({
-      loginPage: "/oauth/authorize",
-      resource: getMcpUrl(),
-      oidcConfig: {
-        loginPage: "/oauth/authorize",
-        consentPage: "/oauth/consent",
-      },
-    }),
-  ],
+  plugins: [mcp(buildMcpPluginOptions())],
 
   databaseHooks: {
     user: {

--- a/tests/COVERAGE-MAP.md
+++ b/tests/COVERAGE-MAP.md
@@ -127,6 +127,7 @@ level headings classify the tracked test paths listed beneath them.
 
 - `tests/unit/shared/better-auth-schema-compatibility.test.ts` — fresh migration chain exposes the MCP OAuth `redirectUrls` column under Better Auth's exact logical field name, and the Drizzle model persists and reads the same stored representation
 - `tests/unit/shared/test-origin-fetch.test.ts` — direct Node.js test clients add the browser-equivalent Origin only to unsafe Better Auth requests while preserving explicit origins, safe methods, and unrelated endpoints
+- `tests/unit/shared/oauth-page-paths.test.ts` — the OAuth plugin's login and consent pages are configured under the Web UI base path, prefixed when one is set and unprefixed at the root
 
 **integration**
 

--- a/tests/unit/shared/oauth-page-paths.test.ts
+++ b/tests/unit/shared/oauth-page-paths.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, test } from "@jest/globals";
+
+const originalAppBasePath = process.env.APP_BASE_PATH;
+
+async function importAuthConfig() {
+  return import("../../../packages/shared/src/auth/better-auth-config.js");
+}
+
+describe("OAuth plugin page configuration follows the deployment base-path prefix", () => {
+  afterEach(() => {
+    if (originalAppBasePath === undefined) {
+      delete process.env.APP_BASE_PATH;
+    } else {
+      process.env.APP_BASE_PATH = originalAppBasePath;
+    }
+  });
+
+  test("plugin is configured with prefixed pages when the Web UI is served under a prefix", async () => {
+    process.env.APP_BASE_PATH = "/app";
+    const { buildMcpPluginOptions } = await importAuthConfig();
+
+    expect(buildMcpPluginOptions()).toMatchObject({
+      loginPage: "/app/oauth/authorize",
+      oidcConfig: {
+        loginPage: "/app/oauth/authorize",
+        consentPage: "/app/oauth/consent",
+      },
+    });
+  });
+
+  test("plugin is configured with root pages when the Web UI is served at the root", async () => {
+    process.env.APP_BASE_PATH = "/";
+    const { buildMcpPluginOptions } = await importAuthConfig();
+
+    expect(buildMcpPluginOptions()).toMatchObject({
+      loginPage: "/oauth/authorize",
+      oidcConfig: {
+        loginPage: "/oauth/authorize",
+        consentPage: "/oauth/consent",
+      },
+    });
+  });
+});


### PR DESCRIPTION
Closes #184

## Problem

Better Auth's `mcp`/`oidc-provider` plugin interpolates its configured `loginPage` and `consentPage` directly into the redirects it issues. Those were hardcoded as root-relative paths, so a deployment serving the Web UI under a base path (`APP_BASE_PATH=/app`) sent users to URLs it does not serve.

The web backend's compensating `GET /oauth/authorize` redirect could not cover this: the plugin issues its redirects from inside `/api/auth` handling and never transits that Express route.

Observed on a container built with `APP_BASE_PATH=/app`:

- **Consent — hard failure.** Bare `/oauth/consent` returns **404**; `/app/oauth/consent` returns **200**. There is no compensating handler for the consent path.
- **Login — degraded.** It still arrived, via the compensating redirect, but only after an extra hop that exposed the unprefixed URL.

## Change

Build the plugin's options in one function that derives both pages from `getAppPrefix()`, and configure the plugin with that function's result — so the configuration and its regression test read the same object, with no string literal between them.

`mcp()` overwrites `oidcConfig.loginPage` with the top-level `loginPage`, so only two of the three configured values ever reach a redirect. All three are set from a single local so none can drift, and the shadowing is documented at the code that relies on it.

**Self-host is unchanged**: an empty prefix yields exactly the previous strings.

## Testing

- Command: `docker build --build-arg APP_BASE_PATH=/app -f config/Dockerfile -t moira-check .` then `curl -i "http://localhost:3099/api/auth/mcp/authorize?client_id=test-client&response_type=code&redirect_uri=http://localhost/cb&code_challenge=abc&code_challenge_method=S256&scope=openid"`, run against two images differing only by this commit
- Outcome: without this change the response is `location: /oauth/authorize?...`; with it, `location: /app/oauth/authorize?...`. Root mode re-checked on a running container: authorize stays unprefixed and `/oauth/consent` serves 200.
- Command: `npm run test:unit -- --file tests/unit/shared/oauth-page-paths.test.ts`
- Outcome: 2 passed. Verified discriminating by injecting each regression separately into working code — hardcoding either page's bare path fails the suite. (Asserting only helper functions did not: an earlier shape passed against a wiring revert.)
- Command: `npm run test:unit`, `npm run test:integration`, `npm run test:workflow`, `npm run test:mcp-tools`
- Outcome: 2102, 681, 893 and 279 passed respectively, 0 failed. API suite run as CI does (saas container, `API_TEST_TARGET=saas`): 418 passed. `tsc --noEmit`, ESLint and Prettier clean.

## Notes

Two hardcoded `/app` literals remain out of scope, in this file's email-verification callback and `web-backend/src/routes/admin.ts`. They are the inverse shape — a prefix unconditionally added — and correct under the only deployment that sets a prefix today, but they do carry a latent self-host issue worth a separate look.

https://claude.ai/code/session_01UmapyMNpS5tnSk9vQuPfeq